### PR TITLE
Drain iterators passed to request

### DIFF
--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import itertools
 import weakref
 
 from requests.adapters import BaseAdapter
@@ -226,6 +227,20 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
                 raise
 
             if resp is not None:
+                inbuilt = isinstance(request.body, (six.string_types,
+                                                    six.text_type,
+                                                    six.binary_type,
+                                                    tuple,
+                                                    list,
+                                                    dict))
+
+                # tee is cool. This lets us drain a provided iterator for
+                # compatibility, but also save the one that was given.
+                if hasattr(request.body, '__iter__') and not inbuilt:
+                    request.body, it = itertools.tee(request.body)
+                    for r in it:
+                        pass
+
                 request._matcher = weakref.ref(matcher)
                 resp.connection = self
                 return resp


### PR DESCRIPTION
Iterate over any iterators passed to the request. This will have been
done by the request process and will handle a very small corner case
where an application expects a generator to be run.

Fixes: #19