### PR TITLE
Remove py26 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Topic :: Software Development :: Testing


### PR DESCRIPTION
As of mitaka, the infra team won't have the resources available to
reasonably test py26, also the oslo team is dropping py26 support
from their libraries. sine we rely on oslo for a lot of our work,
and depend on infra for our CI, we should drop py26 support too.

Change-Id: I94fd52f2fd2f01938530b63ba307a6e7011d4fac
Closes-Bug: 1519510