### PR TITLE
Add circleci testing configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,70 @@
+version: 2
+jobs:
+  py36:
+    docker:
+      - image: circleci/python:3.6
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - py36-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            source venv/bin/activate
+            pip3 install tox
+            tox -e py36 --notest
+
+      - save_cache:
+          paths:
+            - ./venv
+            - .tox/py36
+          key: py36-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+
+      - run:
+          name: run tests
+          command: |
+            source venv/bin/activate
+            tox -e py36
+
+  py27:
+    docker:
+      - image: circleci/python:2.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - py27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+
+      - run:
+          name: install dependencies
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install tox
+            tox -e py27 --notest
+
+      - save_cache:
+          paths:
+            - ./venv
+            - .tox/py27
+          key: py27-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+
+      - run:
+          name: run tests
+          command: |
+            source venv/bin/activate
+            tox -e py27
+
+workflows:
+  version: 2
+  unittest:
+    jobs:
+      - py27
+      - py36


### PR DESCRIPTION
Now that we can no longer rely on zuul try using circleci for testing.
Travis would be my normal go to, but there's a few things i'm not a big
fan of there.