### PR TITLE
Remove .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,4 +1,0 @@
-[gerrit]
-host=review.openstack.org
-port=29418
-project=openstack/requests-mock.git


### PR DESCRIPTION
Moving to github we no longer need gerrit config files.