### PR TITLE
Use set literals throughout project

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -35,12 +35,14 @@ class MockerCore(object):
     same general options available and prevent repeating code.
     """
 
-    _PROXY_FUNCS = set(['last_request',
-                        'add_matcher',
-                        'request_history',
-                        'called',
-                        'called_once',
-                        'call_count'])
+    _PROXY_FUNCS = {
+        'last_request',
+        'add_matcher',
+        'request_history',
+        'called',
+        'called_once',
+        'call_count',
+    }
 
     case_sensitive = False
     """case_sensitive handles a backwards incompatible bug. The URL used to

--- a/requests_mock/tests/test_adapter.py
+++ b/requests_mock/tests/test_adapter.py
@@ -548,7 +548,7 @@ class SessionAdapterTests(base.TestCase):
 
         self.assertEqual('newton', resp.cookies['fig'])
         self.assertEqual('apple', resp.cookies['sugar'])
-        self.assertEqual(set(['/foo', '/bar']), set(resp.cookies.list_paths()))
+        self.assertEqual({'/foo', '/bar'}, set(resp.cookies.list_paths()))
         self.assertEqual(['.example.com'], resp.cookies.list_domains())
 
     def test_cookies_header_with_cb(self):
@@ -598,7 +598,7 @@ class SessionAdapterTests(base.TestCase):
 
         self.assertEqual('newton', resp.cookies['fig'])
         self.assertEqual('apple', resp.cookies['sugar'])
-        self.assertEqual(set(['/foo', '/bar']), set(resp.cookies.list_paths()))
+        self.assertEqual({'/foo', '/bar'}, set(resp.cookies.list_paths()))
         self.assertEqual(['.example.com'], resp.cookies.list_domains())
 
     def test_reading_closed_fp(self):

--- a/requests_mock/tests/test_response.py
+++ b/requests_mock/tests/test_response.py
@@ -108,5 +108,5 @@ class ResponseTests(base.TestCase):
 
         self.assertEqual('newton', resp.cookies['fig'])
         self.assertEqual('apple', resp.cookies['sugar'])
-        self.assertEqual(set(['/foo', '/bar']), set(resp.cookies.list_paths()))
+        self.assertEqual({'/foo', '/bar'}, set(resp.cookies.list_paths()))
         self.assertEqual(['.test.url'], resp.cookies.list_domains())


### PR DESCRIPTION
Set literals are available on all supported Python versions (Introduced in 2.7). Prefer modern Python syntax. Additionally, set literals are always a faster choice:

```
  $ python3 -m timeit 'set([1, 2, 3])'
  1000000 loops, best of 3: 0.231 usec per loop
  $ python3 -m timeit '{1, 2, 3}'
  10000000 loops, best of 3: 0.0745 usec per loop
```