### PR TITLE
Prefer https:// links over http:// in docs and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ requests-mock
 ===============================
 
 .. image:: https://badge.fury.io/py/requests-mock.png
-    :target: http://badge.fury.io/py/requests-mock
+    :target: https://pypi.python.org/pypi/requests-mock
 
 Intro
 =====
@@ -73,7 +73,7 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use this file except in compliance with the License. You may obtain
 a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -82,5 +82,5 @@ License for the specific language governing permissions and limitations
 under the License.
 
 .. _requests: http://python-requests.org
-.. _docs: http://requests-mock.readthedocs.org
+.. _docs: https://requests-mock.readthedocs.io/
 .. _LaunchPad: https://bugs.launchpad.net/requests-mock

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -255,8 +255,8 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 requests_uri = 'http://docs.python-requests.org/en/latest/'
-urllib3_uri = 'http://urllib3.readthedocs.org/en/latest'
-python_uri = 'http://docs.python.org/3'
+urllib3_uri = 'https://urllib3.readthedocs.io/en/latest/'
+python_uri = 'https://docs.python.org/3/'
 intersphinx_mapping = {'requests': (requests_uri, None),
                        'urllib': (python_uri, None),
                        'urllib3': (urllib3_uri, None),

--- a/requests_mock/__init__.py
+++ b/requests_mock/__init__.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/compat.py
+++ b/requests_mock/compat.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/contrib/fixture.py
+++ b/requests_mock/contrib/fixture.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/exceptions.py
+++ b/requests_mock/exceptions.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/base.py
+++ b/requests_mock/tests/base.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_adapter.py
+++ b/requests_mock/tests/test_adapter.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_custom_matchers.py
+++ b/requests_mock/tests/test_custom_matchers.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_fixture.py
+++ b/requests_mock/tests/test_fixture.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_matcher.py
+++ b/requests_mock/tests/test_matcher.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_mocker.py
+++ b/requests_mock/tests/test_mocker.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_request.py
+++ b/requests_mock/tests/test_request.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/requests_mock/tests/test_response.py
+++ b/requests_mock/tests/test_response.py
@@ -2,7 +2,7 @@
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT


### PR DESCRIPTION
Additionally, switch to readthedocs.io instead of readthedocs.org. Read the Docs moved hosting to readthedocs.io instead of readthedocs.org. Fix all links in the project. For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.