### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ requests-mock
 ===============================
 
 .. image:: https://badge.fury.io/py/requests-mock.png
-    :target: https://pypi.python.org/pypi/requests-mock
+    :target: https://pypi.org/project/requests-mock/
 
 .. image:: https://circleci.com/gh/jamielennox/requests-mock.svg?style=svg
     :target: https://circleci.com/gh/jamielennox/requests-mock

--- a/doc/source/fixture.rst
+++ b/doc/source/fixture.rst
@@ -38,5 +38,5 @@ The fixture provides the same interfaces as the adapter.
     ...
 
 
-.. _Fixtures: https://pypi.python.org/pypi/fixtures
-.. _mock: https://pypi.python.org/pypi/mock
+.. _Fixtures: https://pypi.org/project/fixtures/
+.. _mock: https://pypi.org/project/mock/


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html