### PR TITLE
Only try and push to pypi on a tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,20 @@ workflows:
     jobs:
       - py27
       - py36
+  publish:
+    jobs:
+      - py27:
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - py36:
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - pypi:
           requires:
             - py27


### PR DESCRIPTION
CircleCI just tried to push to pypi even though we didn't tag anything.
This seems to be because you have to have the entire workflow tagged
with the filters. This is stupid. Rewrite it in a way that hopefully
doesn't push to pypi all the time.