### PR TITLE
Another attempt at circleci tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,13 @@ workflows:
       - py27:
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
       - py36:
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
       - pypi:
@@ -104,6 +104,6 @@ workflows:
             - py36
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/


### PR DESCRIPTION
This was still trying to push to pypi. My guess is that circleci tags
aren't compared with an AND. Having both a branch and tag filter meant
it was attempting to push for anything on master branch.

Change it so that we ignore all branches for publish and only trigger on
a tag.