### PR TITLE
Include release-notes in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,8 @@ import requests_mock  # noqa
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = ['reno.sphinxext',
+              'sphinx.ext.autodoc',
               'sphinx.ext.doctest',
               'sphinx.ext.viewcode',
               'sphinx.ext.intersphinx']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,6 +16,15 @@ Contents:
    adapter
    contrib
 
+=============
+Release Notes
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   release-notes
+
 Indices and tables
 ==================
 

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -1,0 +1,5 @@
+=============
+Release Notes
+=============
+
+.. release-notes::

--- a/rtfd-requirements.txt
+++ b/rtfd-requirements.txt
@@ -1,1 +1,2 @@
 pbr
+reno

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,9 @@ commands =
 
 [testenv:docs]
 commands = python setup.py build_sphinx
+deps =
+    -r{toxinidir}/rtfd-requirements.txt
+    {[testenv]deps}
 
 [testenv:requests-tip]
 deps =


### PR DESCRIPTION
reno was being used by openstack to generate release notes, but since
the migration we've not done anything with them. It's a great tool and
we should maintain and publish a release note that is more applicable
that tne changelog generated by PBR.