### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ summary = Mock out responses from the requests package
 description-file = README.rst
 license = Apache-2
 license-file = LICENSE
-home-page = https://requests-mock.readthedocs.org/
+home-page = https://requests-mock.readthedocs.io/
 classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of
readthedocs.org. Fix single link in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from
> subdomains on the domain readthedocs.io, instead of on
> readthedocs.org. This change addresses some security concerns around
> site cookies while hosting user generated data on the same domain as
> our dashboard.