### PR TITLE
Record value of stream parameter in request history

### DIFF
--- a/releasenotes/notes/request-history-stream-f1d75b33adcd7e97.yaml
+++ b/releasenotes/notes/request-history-stream-f1d75b33adcd7e97.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - The stream parameter is recorded when the request is sent and available in
+    request history in the same was as parameters like verify or timeout.

--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -36,6 +36,7 @@ class _RequestObjectProxy(object):
         self._timeout = kwargs.pop('timeout', None)
         self._allow_redirects = kwargs.pop('allow_redirects', None)
         self._verify = kwargs.pop('verify', None)
+        self._stream = kwargs.pop('stream', None)
         self._cert = kwargs.pop('cert', None)
         self._proxies = copy.deepcopy(kwargs.pop('proxies', {}))
 
@@ -118,6 +119,10 @@ class _RequestObjectProxy(object):
     @property
     def verify(self):
         return self._verify
+
+    @property
+    def stream(self):
+        return self._stream
 
     @property
     def cert(self):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -52,6 +52,7 @@ class RequestTests(base.TestCase):
         self.assertIs(None, req.timeout)
         self.assertIs(True, req.verify)
         self.assertIs(None, req.cert)
+        self.assertIs(False, req.stream)
 
         # actually it's an OrderedDict, but equality works fine
         self.assertEqual({}, req.proxies)
@@ -74,6 +75,14 @@ class RequestTests(base.TestCase):
         verify = '/path/to/cacerts.pem'
         req = self.do_request(verify=verify)
         self.assertEqual(verify, req.verify)
+
+    def test_stream(self):
+        req = self.do_request()
+        self.assertIs(False, req.stream)
+        req = self.do_request(stream=False)
+        self.assertIs(False, req.stream)
+        req = self.do_request(stream=True)
+        self.assertIs(True, req.stream)
 
     def test_certs(self):
         cert = ('/path/to/cert.pem', 'path/to/key.pem')


### PR DESCRIPTION
All the other parameters sent as part of the request are available on
the request object, except stream. Even though stream may require more
work to get setup correctly in testing we should record the parameter
value and make it available for testing.

Closes: #59