### PR TITLE
base MockException on BaseException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+env
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+*.swp
 env
 
 # C extensions

--- a/requests_mock/exceptions.py
+++ b/requests_mock/exceptions.py
@@ -11,7 +11,7 @@
 # under the License.
 
 
-class MockException(Exception):
+class MockException(BaseException):
     """Base Exception for library"""
 
 

--- a/requests_mock/exceptions.py
+++ b/requests_mock/exceptions.py
@@ -26,5 +26,16 @@ class NoMockAddress(MockException):
                                            self.request.url)
 
 
+class UncalledMockedAddressException(MockException):
+    """The requested url was mocked but never called!"""
+
+    def __init__(self, matcher):
+        self.matcher = matcher
+
+    def __str__(self):
+        return "Mocked address %s %s but never called" % (self.matcher._method,
+                                                          self.matcher._url)
+
+
 class InvalidRequest(MockException):
     """This call cannot be made under a mocked environment"""

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import mock
+import pytest
 import requests
 
 import requests_mock
@@ -51,6 +52,15 @@ class MockerTests(base.TestCase):
         with requests_mock.Mocker() as m:
             self._do_test(m)
         self.assertMockStopped()
+
+    def test_uncalled_mocks_error(self):
+        def uncalled_testcase():
+            with requests_mock.mock() as m:
+                mocked_call = m.get("http://www.zombo.com")
+                assert 0 == mocked_call.call_count
+
+        self.assertRaises(exceptions.UncalledMockedAddressException,
+                          uncalled_testcase)
 
     @mock.patch('requests.adapters.HTTPAdapter.send')
     @requests_mock.mock(real_http=True)


### PR DESCRIPTION
So, I know changing the base of an Exception  is a sensitive topic for a lot of people, and for a good reason.

but for our usecase, I found that in our older codebase there's a few spots where we end up with 

```
try:
    some code
except Exception
    etc
```

I know, I know. This sucks, and we're working to remove these bits, but refactoring flow-by-exception takes time.

We've been running off my fork where I make this change for a few months now and its been super helpful. thoughts?