### PR TITLE
Add a docstring to the pytest fixture

### DIFF
--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -67,6 +67,12 @@ def pytest_addoption(parser):
 
 @_fixture_type(scope='function')  # executed on every test
 def requests_mock(request):
+    """Mock out the requests component of your code with defined responses.
+
+    Mocks out any requests made through the python requests library with useful
+    responses for unit testing. See:
+    https://requests-mock.readthedocs.io/en/latest/
+    """
     case_sensitive = request.config.getini('requests_mock_case_sensitive')
     kw = {'case_sensitive': _bool_value(case_sensitive)}
 


### PR DESCRIPTION
When you run py.test --fixtures there's an error saying that there's no
docstring on our fixture. We can add one of those.