### PR TITLE
Fix discovery of pytest version and default

### DIFF
--- a/releasenotes/notes/fix-pytest-version-discovery-43f27e7e162ed055.yaml
+++ b/releasenotes/notes/fix-pytest-version-discovery-43f27e7e162ed055.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - Fixed a bug relating to how the pytest version was being discovered that
+    meant new versions of pytest were being treated as old versions and would
+    receive bad configuration.

--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -13,8 +13,8 @@ import requests_mock as rm_module
 try:
     from distutils import version
     _pytest_version = version.StrictVersion(pytest.__version__)
-    _pytest29 = pytest_version >= version.StrictVersion('2.9.0')
-    _pytest30 = pytest_version >= version.StrictVersion('3.0.0')
+    _pytest29 = _pytest_version >= version.StrictVersion('2.9.0')
+    _pytest30 = _pytest_version >= version.StrictVersion('3.0.0')
 except Exception:
     _pytest29 = False
     _pytest30 = False
@@ -22,6 +22,7 @@ except Exception:
 
 if not _pytest29:
     _case_type = None
+    _case_default = 'false'
 
     # Copied from pytest 2.9.0 where bool was introduced. It's what happens
     # internally if we specify a bool type argument.
@@ -47,6 +48,7 @@ if not _pytest29:
 
 else:
     _case_type = 'bool'
+    _case_default = False
 
     def _bool_value(value):
         return value
@@ -62,7 +64,7 @@ def pytest_addoption(parser):
     parser.addini('requests_mock_case_sensitive',
                   'Use case sensitive matching in requests_mock',
                   type=_case_type,
-                  default=False)
+                  default=_case_default)
 
 
 @_fixture_type(scope='function')  # executed on every test


### PR DESCRIPTION
So this was a dumb refactoring mistake that was hidden because I was
testing on older versions not newer versions after the refactor.

It means that we were always identifying pytest as an old version, and
(seperately) the default value was then incorrect.

I will scrap the 1.5.1 release and tag this as 1.5.2

Closes: #66