### PR TITLE
Remove unnecessary compatibility shims

### DIFF
--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -14,7 +14,6 @@ import copy
 import json
 
 import requests
-import six
 from six.moves.urllib import parse as urlparse
 
 
@@ -146,7 +145,7 @@ class _RequestObjectProxy(object):
     def text(self):
         body = self.body
 
-        if isinstance(body, six.binary_type):
+        if isinstance(body, bytes):
             body = body.decode('utf-8')
 
         return body

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import io
 import json as jsonutils
 
 from requests.adapters import HTTPAdapter
@@ -103,7 +104,7 @@ def _extract_cookies(request, response, cookies):
         merge_cookies(response.cookies, cookies)
 
 
-class _IOReader(six.BytesIO):
+class _IOReader(io.BytesIO):
     """A reader that makes a BytesIO look like a HTTPResponse.
 
     A HTTPResponse will return an empty string when you read from it after
@@ -113,10 +114,10 @@ class _IOReader(six.BytesIO):
 
     def read(self, *args, **kwargs):
         if self.closed:
-            return six.b('')
+            return b''
 
         # not a new style object in python 2
-        return six.BytesIO.read(self, *args, **kwargs)
+        return io.BytesIO.read(self, *args, **kwargs)
 
 
 def create_response(request, **kwargs):
@@ -147,7 +148,7 @@ def create_response(request, **kwargs):
     json = kwargs.pop('json', None)
     encoding = None
 
-    if content is not None and not isinstance(content, six.binary_type):
+    if content is not None and not isinstance(content, bytes):
         raise TypeError('Content should be binary data')
     if text is not None and not isinstance(text, six.string_types):
         raise TypeError('Text should be string data')
@@ -163,7 +164,7 @@ def create_response(request, **kwargs):
         raw = HTTPResponse(status=kwargs.get('status_code', _DEFAULT_STATUS),
                            headers=kwargs.get('headers', {}),
                            reason=kwargs.get('reason'),
-                           body=body or _IOReader(six.b('')),
+                           body=body or _IOReader(b''),
                            decode_content=False,
                            preload_content=False,
                            original_response=compat._fake_http_response)
@@ -208,7 +209,7 @@ class _MatcherResponse(object):
         text = self._params.get('text')
 
         if content is not None and not (callable(content) or
-                                        isinstance(content, six.binary_type)):
+                                        isinstance(content, bytes)):
             raise TypeError('Content should be a callback or binary data')
 
         if text is not None and not (callable(text) or

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -58,7 +58,7 @@ class SessionAdapterTests(base.TestCase):
         self.assertEqual(qs, self.adapter.last_request.qs)
 
     def test_content(self):
-        data = six.b('testdata')
+        data = b'testdata'
 
         self.adapter.register_uri('GET',
                                   self.url,
@@ -71,7 +71,7 @@ class SessionAdapterTests(base.TestCase):
 
     def test_content_callback(self):
         status_code = 401
-        data = six.b('testdata')
+        data = b'testdata'
 
         def _content_cb(request, context):
             context.status_code = status_code
@@ -88,33 +88,33 @@ class SessionAdapterTests(base.TestCase):
         self.assertLastRequest()
 
     def test_text(self):
-        data = 'testdata'
+        data = u'testdata'
 
         self.adapter.register_uri('GET',
                                   self.url,
                                   text=data,
                                   headers=self.headers)
         resp = self.session.get(self.url)
-        self.assertEqual(six.b(data), resp.content)
-        self.assertEqual(six.u(data), resp.text)
+        self.assertEqual(data.encode('utf-8'), resp.content)
+        self.assertEqual(data, resp.text)
         self.assertEqual('utf-8', resp.encoding)
         self.assertHeaders(resp)
         self.assertLastRequest()
 
     def test_text_callback(self):
         status_code = 401
-        data = 'testdata'
+        data = u'testdata'
 
         def _text_cb(request, context):
             context.status_code = status_code
             context.headers.update(self.headers)
-            return six.u(data)
+            return data
 
         self.adapter.register_uri('GET', self.url, text=_text_cb)
         resp = self.session.get(self.url)
         self.assertEqual(status_code, resp.status_code)
-        self.assertEqual(six.u(data), resp.text)
-        self.assertEqual(six.b(data), resp.content)
+        self.assertEqual(data, resp.text)
+        self.assertEqual(data.encode('utf-8'), resp.content)
         self.assertEqual('utf-8', resp.encoding)
         self.assertHeaders(resp)
         self.assertLastRequest()
@@ -126,8 +126,8 @@ class SessionAdapterTests(base.TestCase):
                                   json=json_data,
                                   headers=self.headers)
         resp = self.session.get(self.url)
-        self.assertEqual(six.b('{"hello": "world"}'), resp.content)
-        self.assertEqual(six.u('{"hello": "world"}'), resp.text)
+        self.assertEqual(b'{"hello": "world"}', resp.content)
+        self.assertEqual(u'{"hello": "world"}', resp.text)
         self.assertEqual(json_data, resp.json())
         self.assertEqual('utf-8', resp.encoding)
         self.assertHeaders(resp)
@@ -136,7 +136,7 @@ class SessionAdapterTests(base.TestCase):
     def test_json_callback(self):
         status_code = 401
         json_data = {'hello': 'world'}
-        data = '{"hello": "world"}'
+        data = u'{"hello": "world"}'
 
         def _json_cb(request, context):
             context.status_code = status_code
@@ -147,8 +147,8 @@ class SessionAdapterTests(base.TestCase):
         resp = self.session.get(self.url)
         self.assertEqual(status_code, resp.status_code)
         self.assertEqual(json_data, resp.json())
-        self.assertEqual(six.u(data), resp.text)
-        self.assertEqual(six.b(data), resp.content)
+        self.assertEqual(data, resp.text)
+        self.assertEqual(data.encode('utf-8'), resp.content)
         self.assertEqual('utf-8', resp.encoding)
         self.assertHeaders(resp)
         self.assertLastRequest()
@@ -156,7 +156,7 @@ class SessionAdapterTests(base.TestCase):
     def test_no_body(self):
         self.adapter.register_uri('GET', self.url)
         resp = self.session.get(self.url)
-        self.assertEqual(six.b(''), resp.content)
+        self.assertEqual(b'', resp.content)
         self.assertEqual(200, resp.status_code)
 
     def test_multiple_body_elements(self):
@@ -164,8 +164,8 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           self.url,
                           'GET',
-                          content=six.b('b'),
-                          text=six.u('u'))
+                          content=b'b',
+                          text=u'u')
 
     def test_multiple_responses(self):
         inp = [{'status_code': 400, 'text': 'abcd'},
@@ -263,14 +263,14 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          content=six.u('unicode'))
+                          content=u'unicode')
 
     def test_dont_pass_empty_string_as_content(self):
         self.assertRaises(TypeError,
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          content=six.u(''))
+                          content=u'')
 
     def test_dont_pass_bytes_as_text(self):
         if six.PY2:
@@ -280,7 +280,7 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          text=six.b('bytes'))
+                          text=b'bytes')
 
     def test_dont_pass_empty_string_as_text(self):
         if six.PY2:
@@ -290,7 +290,7 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          text=six.b(''))
+                          text=b'')
 
     def test_dont_pass_non_str_as_content(self):
         self.assertRaises(TypeError,
@@ -610,7 +610,7 @@ class SessionAdapterTests(base.TestCase):
 
         data = resp.raw.read()
 
-        self.assertIsInstance(data, six.binary_type)
+        self.assertIsInstance(data, bytes)
         self.assertEqual(0, len(data))
 
     def test_case_sensitive_headers(self):

--- a/tests/test_custom_matchers.py
+++ b/tests/test_custom_matchers.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import requests
-import six
 
 import requests_mock
 from . import base
@@ -28,7 +27,7 @@ class FailMatcher(object):
 
 
 def match_all(request):
-    return requests_mock.create_response(request, content=six.b('data'))
+    return requests_mock.create_response(request, content=b'data')
 
 
 def test_a(request):
@@ -42,7 +41,7 @@ class CustomMatchersTests(base.TestCase):
 
     def assertMatchAll(self, resp):
         self.assertEqual(200, resp.status_code)
-        self.assertEqual(resp.text, six.u('data'))
+        self.assertEqual(resp.text, u'data')
 
     @requests_mock.Mocker()
     def test_custom_matcher(self, mocker):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import io
 import pickle
 import six
 
@@ -49,12 +50,12 @@ class ResponseTests(base.TestCase):
 
         # this only works on python 2 because bytes is a string
         if six.PY3:
-            self.assertRaises(TypeError, self.create_response, text=six.b(''))
+            self.assertRaises(TypeError, self.create_response, text=b'')
 
     def test_text_type(self):
-        self.assertRaises(TypeError, self.create_response, content=six.u('t'))
+        self.assertRaises(TypeError, self.create_response, content=u't')
         self.assertRaises(TypeError, self.create_response, content={'a': 1})
-        self.assertRaises(TypeError, self.create_response, content=six.u(''))
+        self.assertRaises(TypeError, self.create_response, content=u'')
 
     def test_json_body(self):
         data = {'a': 1}
@@ -62,17 +63,17 @@ class ResponseTests(base.TestCase):
 
         self.assertEqual('{"a": 1}', resp.text)
         self.assertIsInstance(resp.text, six.string_types)
-        self.assertIsInstance(resp.content, six.binary_type)
+        self.assertIsInstance(resp.content, bytes)
         self.assertEqual(data, resp.json())
 
     def test_body_body(self):
-        value = 'data'
-        body = six.BytesIO(six.b(value))
+        value = b'data'
+        body = io.BytesIO(value)
         resp = self.create_response(body=body)
 
-        self.assertEqual(value, resp.text)
+        self.assertEqual(value.decode(), resp.text)
         self.assertIsInstance(resp.text, six.string_types)
-        self.assertIsInstance(resp.content, six.binary_type)
+        self.assertIsInstance(resp.content, bytes)
 
     def test_setting_connection(self):
         conn = object()


### PR DESCRIPTION
The type bytes is available on all supported Pythons. On Python 2.7, it
is an alias for str, same as six.binary_type.

Likewise, io.BytesIO is available on all supported Pythons. It is always
a stream implementation using an in-memory bytes buffer.

Byte literals and Unicode literals are available on all supported
Pythons.

Makes the code more forward compatible with Python 3.