### PR TITLE
Add discovery of charset in headers

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -17,6 +17,7 @@ from requests.cookies import MockRequest, MockResponse
 from requests.cookies import RequestsCookieJar
 from requests.cookies import merge_cookies, cookiejar_from_dict
 from requests.packages.urllib3.response import HTTPResponse
+from requests.utils import get_encoding_from_headers
 import six
 
 from requests_mock import compat
@@ -170,6 +171,10 @@ def create_response(request, **kwargs):
 
     response = _http_adapter.build_response(request, raw)
     response.connection = connection
+
+    header_encoding = get_encoding_from_headers(response.headers)
+    if header_encoding:
+        encoding = header_encoding
     response.encoding = encoding
 
     _extract_cookies(request, response, kwargs.get('cookies'))

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -73,6 +73,38 @@ class ResponseTests(base.TestCase):
         self.assertIsInstance(resp.text, six.string_types)
         self.assertIsInstance(resp.content, six.binary_type)
 
+    def test_content_with_charset_header(self):
+        data = 'data'
+        content = six.b(data)
+        headers = {'Content-Type': 'text/html;charset=utf-8'}
+        resp = self.create_response(content=content, headers=headers)
+
+        self.assertEqual(data, resp.text)
+        self.assertIsInstance(resp.text, six.string_types)
+        self.assertIsInstance(resp.content, six.binary_type)
+        self.assertEqual(resp.encoding, 'utf-8')
+
+    def test_content_with_charset_header_lowercase(self):
+        data = 'data'
+        content = six.b(data)
+        headers = {'content-type': 'text/html;charset=utf-8'}
+        resp = self.create_response(content=content, headers=headers)
+
+        self.assertEqual(data, resp.text)
+        self.assertIsInstance(resp.text, six.string_types)
+        self.assertIsInstance(resp.content, six.binary_type)
+        self.assertEqual(resp.encoding, 'utf-8')
+
+    def test_content_without_charset_header(self):
+        data = 'data'
+        content = six.b(data)
+        resp = self.create_response(content=content)
+
+        self.assertEqual(data, resp.text)
+        self.assertIsInstance(resp.text, six.string_types)
+        self.assertIsInstance(resp.content, six.binary_type)
+        self.assertEqual(resp.encoding, None)
+
     def test_setting_connection(self):
         conn = object()
         resp = self.create_response(connection=conn)


### PR DESCRIPTION
Sets the encoding according to the `Content-Type` header as in the **requests** package, because currently `None` is always being returned.

https://github.com/requests/requests/blob/75bdc998e2d430a35d869b2abf1779bd0d34890e/requests/adapters.py#L274

