### PR TITLE
Clarify the pytest configuration documentation

### DIFF
--- a/doc/source/pytest.rst
+++ b/doc/source/pytest.rst
@@ -19,3 +19,12 @@ The fixture then provides the same interface as the :py:class:`requests_mock.Moc
     ...
 
 .. _pytest: https://pytest.org
+
+Configuration
+=============
+
+Some options are available to be read from pytest's configuration mechanism.
+
+These options are:
+
+   `requests_mock_case_sensitive`: (bool) Turn on case sensitivity in path matching.

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -56,6 +56,11 @@ class MockerCore(object):
 
     requests_mock.mock.case_sensitive = True
 
+    or for pytest set in your configuration:
+
+    [pytest]
+    requests_mock_case_sensitive = True
+
     which will prevent the lowercase being executed and return case sensitive
     url and query information.
 


### PR DESCRIPTION
Configuring requests_mock_case_sensitive is different for pytest. Make
sure that's communicated correctly.

Related: #75