### PR TITLE
Drop _matcher from request pickled state

### DIFF
--- a/releasenotes/notes/Allow-pickling-response-fe751b0a760a5001.yaml
+++ b/releasenotes/notes/Allow-pickling-response-fe751b0a760a5001.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - Remove weakref objects from the request/response that will allow the
+    objects to be pickled with the regular python mechanisms. #78

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -10,10 +10,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import pickle
+
 import mock
 import requests
 
 import requests_mock
+from requests_mock import adapter
 from requests_mock import exceptions
 from requests_mock import response
 from . import base
@@ -441,3 +444,19 @@ class MockerHttpMethodsTests(base.TestCase):
                           requests.post,
                           url,
                           data='goodbye world')
+
+    @requests_mock.mock()
+    def test_mocker_pickle(self, m):
+        url = 'http://www.example.com'
+        text = 'hello world'
+        m.get(url, text=text)
+
+        orig_resp = requests.get(url)
+        self.assertEqual(text, orig_resp.text)
+
+        d = pickle.dumps(orig_resp)
+        new_resp = pickle.loads(d)
+
+        self.assertEqual(text, new_resp.text)
+        self.assertIsInstance(orig_resp.request.matcher, adapter._Matcher)
+        self.assertIsNone(new_resp.request.matcher)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import pickle
 import six
 
 from requests_mock import adapter
@@ -110,3 +111,16 @@ class ResponseTests(base.TestCase):
         self.assertEqual('apple', resp.cookies['sugar'])
         self.assertEqual({'/foo', '/bar'}, set(resp.cookies.list_paths()))
         self.assertEqual(['.test.url'], resp.cookies.list_domains())
+
+    def test_response_pickle(self):
+        text = 'hello world'
+        jar = response.CookieJar()
+        jar.set('fig', 'newton', path='/foo', domain='.test.url')
+        orig_resp = self.create_response(cookies=jar, text=text)
+
+        d = pickle.dumps(orig_resp)
+        new_resp = pickle.loads(d)
+
+        self.assertEqual(text, new_resp.text)
+        self.assertEqual('newton', new_resp.cookies['fig'])
+        self.assertIsNone(new_resp.request.matcher)


### PR DESCRIPTION
We can't pickle a weakref object and therefore pickling a
request/response doesn't currently work. Given that it's already a
weakref it's fine to just drop it and return None.

Closes: #78