### PR TITLE
Add support for purl

### DIFF
--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -20,6 +20,13 @@ from requests_mock import exceptions
 from requests_mock.request import _RequestObjectProxy
 from requests_mock.response import _MatcherResponse
 
+try:
+    import purl
+    purl_types = (purl.URL,)
+except ImportError:
+    purl = None
+    purl_types = ()
+
 ANY = object()
 
 
@@ -90,6 +97,16 @@ class _Matcher(_RequestHistoryTracker):
             self._netloc = url_parts.netloc.lower()
             self._path = url_parts.path or '/'
             self._query = url_parts.query
+
+            if not case_sensitive:
+                self._path = self._path.lower()
+                self._query = self._query.lower()
+
+        elif isinstance(url, purl_types):
+            self._scheme = url.scheme()
+            self._netloc = url.netloc()
+            self._path = url.path()
+            self._query = url.query()
 
             if not case_sensitive:
                 self._path = self._path.lower()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 fixtures
 mock
+purl
 pytest
 sphinx
 testrepository>=0.0.18

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -13,6 +13,7 @@
 import json
 import re
 
+import purl
 import requests
 import six
 from six.moves.urllib import parse as urlparse
@@ -326,6 +327,12 @@ class SessionAdapterTests(base.TestCase):
         for u in ('mock://www.tester.com/a', 'mock://abc.tester.com'):
             resp = self.session.get(u)
             self.assertEqual('resp', resp.text)
+
+    def test_with_purl(self):
+        self.adapter.register_uri('GET', purl.URL('mock://www.tester.com/a'), text='resp')
+
+        resp = self.session.get('mock://www.tester.com/a')
+        self.assertEqual('resp', resp.text)
 
     def test_requests_in_history_on_no_match(self):
         self.assertRaises(requests_mock.NoMockAddress,


### PR DESCRIPTION
This adds support for matching `purl.URL` objects. It doesn't add `purl` as a dependency, it's only needed for the test I added.
I want to be able to do `m.get(my_purl_url, ...)`. I know I can always do `m.get(str(my_purl_url))` but then I'll have to repeat the `str` call on every mock call.