### PR TITLE
Respect user provided content encoding type

### DIFF
--- a/releasenotes/notes/user-response-encoding-b2eea39404140164.yaml
+++ b/releasenotes/notes/user-response-encoding-b2eea39404140164.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    If you specified a charset in the Content-Type of a response it would be
+    ignored and overriden with either 'utf-8' or None depending on the type of
+    response content passed in. If you pass this value we should honour it and
+    perform the encoding correctly.

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -124,3 +124,9 @@ class ResponseTests(base.TestCase):
         self.assertEqual(text, new_resp.text)
         self.assertEqual('newton', new_resp.cookies['fig'])
         self.assertIsNone(new_resp.request.matcher)
+
+    def test_response_encoding(self):
+        headers = {"content-type": "text/html; charset=ISO-8859-1"}
+        resp = self.create_response(headers=headers,
+                                    text="<html><body></body></html")
+        self.assertEqual('ISO-8859-1', resp.encoding)


### PR DESCRIPTION
If you provide a encoding type via a Content-Type header then
requests-mock was overriding that with either utf-8 or None. We should
trust that the user was setting the value they want.

Closes: #86