### PR TITLE
Fix PEP8 failure in test_adapter

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -329,7 +329,9 @@ class SessionAdapterTests(base.TestCase):
             self.assertEqual('resp', resp.text)
 
     def test_with_purl(self):
-        self.adapter.register_uri('GET', purl.URL('mock://www.tester.com/a'), text='resp')
+        self.adapter.register_uri('GET',
+                                  purl.URL('mock://www.tester.com/a'),
+                                  text='resp')
 
         resp = self.session.get('mock://www.tester.com/a')
         self.assertEqual('resp', resp.text)


### PR DESCRIPTION
Flake8 is still set up locally to use an 80 char line length. This is
debatable, but i'm going to keep it for now.