### PR TITLE
logger added to adapter.py

### DIFF
--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -20,6 +20,10 @@ from requests_mock import exceptions
 from requests_mock.request import _RequestObjectProxy
 from requests_mock.response import _MatcherResponse
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     import purl
     purl_types = (purl.URL,)
@@ -245,6 +249,7 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
             if resp is not None:
                 request._matcher = weakref.ref(matcher)
                 resp.connection = self
+                logger.debug('{} \"{} \" {}'.format(request._request.url,request._request.method, resp.status_code))
                 return resp
 
         raise exceptions.NoMockAddress(request)

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -249,7 +249,7 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
             if resp is not None:
                 request._matcher = weakref.ref(matcher)
                 resp.connection = self
-                logger.debug('{} \"{} \" {}'.format(request._request.url,request._request.method, resp.status_code))
+                logger.debug('{} {} {}'.format(request._request.method,request._request.url, resp.status_code))
                 return resp
 
         raise exceptions.NoMockAddress(request)


### PR DESCRIPTION
enables the user to use `l=logging.getLogger('requests_mock.adapters')` to log all mocked requests and responses, similar to using `l=logging.getLogger('urllib3.connectionpool')`