### PR TITLE
Give people a way of asking to return NoMockAddress

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -219,10 +219,25 @@ class _MatcherResponse(object):
                                      isinstance(text, six.string_types)):
             raise TypeError('Text should be a callback or string data')
 
+    def _raise_exception(self, request):
+        # If the response is an exception raise it. If the exception passed is
+        # NoMockAddress we should raise it in the correct way so a user can
+        # request that NoMockAddress is actually raised on purpose.
+
+        if self._exc:
+            try:
+                subclass = issubclass(self._exc, exceptions.NoMockAddress)
+            except TypeError:
+                subclass = False
+
+            if subclass:
+                raise self._exc(request)
+            else:
+                raise self._exc
+
     def get_response(self, request):
         # if an error was requested then raise that instead of doing response
-        if self._exc:
-            raise self._exc
+        self._raise_exception(request)
 
         # If a cookie dict is passed convert it into a CookieJar so that the
         # cookies object available in a callback context is always a jar.

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -487,6 +487,24 @@ class SessionAdapterTests(base.TestCase):
                           exc=MyExc,
                           text='fail')
 
+    def test_raises_no_address(self):
+        m = self.adapter.register_uri(
+            'GET',
+            self.url,
+            [{'text': 'success'}, {'exc': requests_mock.NoMockAddress}]
+        )
+
+        resp = self.session.get(self.url)
+        self.assertEqual('success', resp.text)
+
+        e = self.assertRaises(requests_mock.NoMockAddress,
+                              self.session.get,
+                              self.url)
+
+        self.assertIsInstance(e, requests_mock.NoMockAddress)
+        self.assertEqual(self.url, e.request.url)
+        self.assertEqual(2, m.call_count)
+
     def test_sets_request_matcher_in_history(self):
         url1 = '%s://test1.url/' % self.PREFIX
         url2 = '%s://test2.url/' % self.PREFIX


### PR DESCRIPTION
NoMockAddress needs to be called with the request in it. If for whatever
reason a user wanted to emulate that they couldn't easily so we can
provide a reasonably easy work around.