### PR TITLE
Add release notes for requests version pin

### DIFF
--- a/releasenotes/notes/pin-requests-version-e0f090aa31dc86c3.yaml
+++ b/releasenotes/notes/pin-requests-version-e0f090aa31dc86c3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Pins version of requests to <3 to prepare for new release of requests in future.


### PR DESCRIPTION
We didn't add release notes in the initial PR. Ensure they are present
for release time.