### PR TITLE
Keep blank values query string values on request history

### DIFF
--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -110,7 +110,7 @@ class _RequestObjectProxy(object):
     @property
     def qs(self):
         if self._qs is None:
-            self._qs = urlparse.parse_qs(self.query)
+            self._qs = urlparse.parse_qs(self.query, keep_blank_values=True)
 
         return self._qs
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -130,3 +130,7 @@ class RequestTests(base.TestCase):
     def test_to_string(self):
         req = self.do_request(url='https://host.example.com/path')
         self.assertEqual('GET https://host.example.com/path', str(req))
+
+    def test_empty_query_string(self):
+        req = self.do_request(url='https://host.example.com/path?key')
+        self.assertEqual([''], req.qs['key'])


### PR DESCRIPTION
We've already added empty query string matching to the matcher logic, we
should also use this when looking at request history.

Related: #101