### PR TITLE
Easier session scoped mock

### DIFF
--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -73,7 +73,7 @@ class MockerTests(base.TestCase):
         self.assertEqual('resp_a', resp_a.text)
         self.assertEqual('resp_b', resp_b.text)
 
-        self.assertIs(requests.Session.send, original_send)
+        self.assertEqual(requests.Session.send, original_send)
         self.assertNotEqual(session_a.send, session_a_original_send)
         self.assertNotEqual(session_b.send, session_b_original_send)
         self.assertNotEqual(session_a.send, session_b.send)


### PR DESCRIPTION
`Mocker()` usually mocks `requests.Session.send`. This results in a global effect.

This pr adds an argument to `Mocker` that allows to mock a single `Session` instance in a similar way, without the need to add custom adapters to a session and removing existing ones.

```python
import requests
import requests_mock

my_session = requests.Session()
m = requests_mock.Mocker(session=my_session)
# ...
```

Use cases include mocking the session of several independent components that call the same end-point and we are only interested in the call order within a single component, but not in relation to each other.