### PR TITLE
Expose real_http as a public property

### DIFF
--- a/releasenotes/notes/set-real-http-on-mocker-01eb26b65697466d.yaml
+++ b/releasenotes/notes/set-real-http-on-mocker-01eb26b65697466d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Make real_http variable on Mocker object public. This means you can change
+    the value of the parameter after the object has been created. This will
+    allow setting it in situations like pytest where you may not be able to set
+    __init__ time options.

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -74,7 +74,7 @@ class MockerCore(object):
             adapter.Adapter(case_sensitive=self.case_sensitive)
         )
 
-        self._real_http = kwargs.pop('real_http', False)
+        self.real_http = kwargs.pop('real_http', False)
         self._last_send = None
 
         if kwargs:
@@ -110,7 +110,7 @@ class MockerCore(object):
             try:
                 return _original_send(session, request, **kwargs)
             except exceptions.NoMockAddress:
-                if not self._real_http:
+                if not self.real_http:
                     raise
             except adapter._RunRealHTTP:
                 # this mocker wants you to run the request through the real
@@ -208,7 +208,7 @@ class Mocker(MockerCore):
         """
         m = Mocker(
             kw=self._kw,
-            real_http=self._real_http,
+            real_http=self.real_http,
             case_sensitive=self.case_sensitive
         )
         return m

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -76,6 +76,40 @@ class MockerTests(base.TestCase):
         self.assertEqual(test_text, resp.text)
         self.assertEqual(test_bytes, resp.content)
 
+    @mock.patch('requests.adapters.HTTPAdapter.send')
+    def test_real_http_changes(self, real_send):
+        url = 'http://www.google.com/'
+        test_text = 'real http data'
+        test_bytes = test_text.encode('utf-8')
+
+        req = requests.Request(method='GET', url=url)
+        real_send.return_value = response.create_response(req.prepare(),
+                                                          status_code=200,
+                                                          content=test_bytes)
+
+        with requests_mock.Mocker() as m:
+            # real_http defaults to false so should raise NoMockAddress
+
+            self.assertRaises(exceptions.NoMockAddress,
+                              requests.get,
+                              url)
+
+            self.assertEqual(1, m.call_count)
+            self.assertEqual(0, real_send.call_count)
+
+            # change the value of real_http mid test
+            m.real_http = True
+
+            # fetch the url again and it should go through to the real url that
+            # we've mocked out at a lower level.
+            resp = requests.get(url)
+
+        self.assertEqual(1, real_send.call_count)
+        self.assertEqual(url, real_send.call_args[0][0].url)
+
+        self.assertEqual(test_text, resp.text)
+        self.assertEqual(test_bytes, resp.content)
+
     @requests_mock.mock()
     def test_with_test_decorator(self, m):
         self._do_test(m)
@@ -207,7 +241,7 @@ class MockerTests(base.TestCase):
         copy_of_mocker = mocker.copy()
         self.assertIsNot(copy_of_mocker, mocker)
         self.assertEqual(copy_of_mocker._kw, mocker._kw)
-        self.assertEqual(copy_of_mocker._real_http, mocker._real_http)
+        self.assertEqual(copy_of_mocker.real_http, mocker.real_http)
 
 
 class MockerHttpMethodsTests(base.TestCase):


### PR DESCRIPTION
I set these as private by default as I wasn't sure how the library would
turn out to use them. There is now a use case for having it public so we
should expose it properly.

Related: #111