### PR TITLE
Set real_http from pytest settings

### DIFF
--- a/releasenotes/notes/support-real-http-in-pytest-250c34470a836e98.yaml
+++ b/releasenotes/notes/support-real-http-in-pytest-250c34470a836e98.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Allow real_http to be specified globally when using a pytest fixture.
+    Typically you would want this set once on the mocker but it can on occasion
+    be useful to set it globally.

--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -66,6 +66,11 @@ def pytest_addoption(parser):
                   type=_case_type,
                   default=_case_default)
 
+    parser.addini('requests_mock_real_http',
+                  'Fallback to real http requests in requests_mock',
+                  type=_case_type,
+                  default=_case_default)
+
 
 @_fixture_type(scope='function')  # executed on every test
 def requests_mock(request):
@@ -76,7 +81,12 @@ def requests_mock(request):
     https://requests-mock.readthedocs.io/en/latest/
     """
     case_sensitive = request.config.getini('requests_mock_case_sensitive')
-    kw = {'case_sensitive': _bool_value(case_sensitive)}
+    real_http = request.config.getini('requests_mock_real_http')
+
+    kw = {
+        'case_sensitive': _bool_value(case_sensitive),
+        'real_http': _bool_value(real_http),
+    }
 
     with rm_module.Mocker(**kw) as m:
         yield m


### PR DESCRIPTION
We've previously allowed case_insensitive to be set from a pytest ini
config file, for some reason we never gave the option to set real_http
here as well.

It's a bit less useful, but it's still got some useful cases and we
should support it.

Closes: #111