### PR TITLE
fix redirects (#105) and mock nesting

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -26,7 +26,6 @@ POST = 'POST'
 PUT = 'PUT'
 
 _original_send = requests.Session.send
-_original_get_adapter = requests.Session.get_adapter
 
 
 class MockerCore(object):

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -90,12 +90,13 @@ class MockerCore(object):
             raise RuntimeError('Mocker has already been started')
 
         self._last_send = requests.Session.send
+        self._last_get_adapter = requests.Session.get_adapter
 
         def _fake_get_adapter(session, url):
             return self._adapter
 
         def _fake_send(session, request, **kwargs):
-            _last_get_adapter = requests.Session.get_adapter
+            # mock get_adapter
             requests.Session.get_adapter = _fake_get_adapter
 
             # NOTE(jamielennox): self._last_send vs _original_send. Whilst it
@@ -118,15 +119,13 @@ class MockerCore(object):
                 # requests library rather than the mocking. Let it.
                 pass
             finally:
-                requests.Session.get_adapter = _last_get_adapter
+                # restore get_adapter
+                requests.Session.get_adapter = self._last_get_adapter
 
             # if we are here it means we must run the real http request
-            try:
-                requests.Session.get_adapter = _original_get_adapter
-                return _original_send(session, request, **kwargs)
-            finally:
-                requests.Session.get_adapter = _last_get_adapter
-
+            # Or, with nested mocks, to the parent mock, that is why we use
+            # _last_send here instead of _original_send
+            return self._last_send(session, request, **kwargs)
 
         requests.Session.send = _fake_send
 

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -1,8 +1,8 @@
 try:
     from http import HTTPStatus
-    HTTPStatus_FOUND = HTTPStatus.FOUND
+    HTTP_STATUS_FOUND = HTTPStatus.FOUND
 except ImportError:
-    from httplib import FOUND as HTTPStatus_FOUND
+    from httplib import FOUND as HTTP_STATUS_FOUND
 
 import pytest
 import requests
@@ -27,10 +27,10 @@ def test_redirect_and_nesting():
             middle_mock.get(url_middle, text='middle' + url_middle)
 
             with requests_mock.Mocker() as inner_mock:
-                inner_mock.post(url_inner, status_code=HTTPStatus_FOUND, headers={'location': url})
+                inner_mock.post(url_inner, status_code=HTTP_STATUS_FOUND, headers={'location': url})
                 inner_mock.get(url, real_http=True)
 
-                assert 'outer' + url == requests.post(url_inner).text
+                assert 'outer' + url == requests.post(url_inner).text  # nosec
                 with pytest.raises(requests_mock.NoMockAddress):
                     requests.get(url_middle)
                 with pytest.raises(requests_mock.NoMockAddress):
@@ -39,15 +39,15 @@ def test_redirect_and_nesting():
             # back to middle mock
             with pytest.raises(requests_mock.NoMockAddress):
                 requests.post(url_inner)
-            assert 'middle' + url_middle == requests.get(url_middle).text
-            assert 'outer' + url_outer == requests.get(url_outer).text
+            assert 'middle' + url_middle == requests.get(url_middle).text  # nosec
+            assert 'outer' + url_outer == requests.get(url_outer).text  # nosec
 
         # back to outter mock
         with pytest.raises(requests_mock.NoMockAddress):
             requests.post(url_inner)
         with pytest.raises(requests_mock.NoMockAddress):
             requests.get(url_middle)
-        assert 'outer' + url_outer == requests.get(url_outer).text
+        assert 'outer' + url_outer == requests.get(url_outer).text  # nosec
 
 
 class TestClass(object):

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -1,9 +1,24 @@
+try:
+    from http import HTTPStatus
+    HTTPStatus_FOUND = HTTPStatus.FOUND
+except ImportError:
+    from httplib import FOUND as HTTPStatus_FOUND
+
 import requests
 
 
 def test_simple(requests_mock):
     requests_mock.get('https://httpbin.org/get', text='data')
     assert 'data' == requests.get('https://httpbin.org/get').text
+
+
+def test_redirect(requests_mock):
+    url1 = "https://mocked.example.com/"
+    url2 = "https://www.example.com/"
+    requests_mock.post(url1, status_code=HTTPStatus_FOUND, headers={'location': url2})
+    requests_mock.get(url2, real_http=True)
+
+    requests.post(url1)
 
 
 class TestClass(object):

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -4,7 +4,9 @@ try:
 except ImportError:
     from httplib import FOUND as HTTPStatus_FOUND
 
+import pytest
 import requests
+import requests_mock
 
 
 def test_simple(requests_mock):
@@ -12,13 +14,40 @@ def test_simple(requests_mock):
     assert 'data' == requests.get('https://httpbin.org/get').text
 
 
-def test_redirect(requests_mock):
-    url1 = "https://mocked.example.com/"
-    url2 = "https://www.example.com/"
-    requests_mock.post(url1, status_code=HTTPStatus_FOUND, headers={'location': url2})
-    requests_mock.get(url2, real_http=True)
+def test_redirect_and_nesting():
+    url_inner = "inner_mock://example.test/"
+    url_middle = "middle_mock://example.test/"
+    url_outer = "outer_mock://example.test/"
+    url = "https://www.example.com/"
+    with requests_mock.Mocker() as outer_mock:
+        outer_mock.get(url, text='outer' + url)
+        outer_mock.get(url_outer, text='outer' + url_outer)
 
-    requests.post(url1)
+        with requests_mock.Mocker(real_http=True) as middle_mock:
+            middle_mock.get(url_middle, text='middle' + url_middle)
+
+            with requests_mock.Mocker() as inner_mock:
+                inner_mock.post(url_inner, status_code=HTTPStatus_FOUND, headers={'location': url})
+                inner_mock.get(url, real_http=True)
+
+                assert 'outer' + url == requests.post(url_inner).text
+                with pytest.raises(requests_mock.NoMockAddress):
+                    requests.get(url_middle)
+                with pytest.raises(requests_mock.NoMockAddress):
+                    requests.get(url_outer)
+
+            # back to middle mock
+            with pytest.raises(requests_mock.NoMockAddress):
+                requests.post(url_inner)
+            assert 'middle' + url_middle == requests.get(url_middle).text
+            assert 'outer' + url_outer == requests.get(url_outer).text
+
+        # back to outter mock
+        with pytest.raises(requests_mock.NoMockAddress):
+            requests.post(url_inner)
+        with pytest.raises(requests_mock.NoMockAddress):
+            requests.get(url_middle)
+        assert 'outer' + url_outer == requests.get(url_outer).text
 
 
 class TestClass(object):


### PR DESCRIPTION
I took the example from #105 which does indeed raise an error on `master`
~To fix the problem I took the same approach used for send: when `NoMockAddress` is raised while `self._real_http` is `True` or when `_RunRealHTTP` is raised I use `_original_get_adapter`.~

**Edit**: I extended the test to include mock nesting (since my first commit completely bypasses any outer mock).
To fix the problem and improve mock nesting:
- `requests.Session.get_adapter` is restored from a value taken at the start of the current mock, instead of the beggining of the `_fake_send` function (this allows redirects)
- `_last_send` is used when `NoMockAddress` is raised while `self._real_http` is `True`, or when `_RunRealHTTP` is raised, in order to pass the request to the outer mock

After this fix the added test passes without error.

~(I am not sure `_last_send` or `_last_get_adapter` offer any useful functionality though)~