### PR TITLE
docs: update examples to match Read the Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ As a context manager:
 
 .. code:: python
 
-    >>> with requests_mock.mock() as m:
+    >>> with requests_mock.Mocker() as m:
     ...     m.get('http://test.com', text='data')
     ...     requests.get('http://test.com').text
     ...
@@ -54,7 +54,7 @@ Or as a decorator:
 
 .. code:: python
 
-    >>> @requests_mock.mock()
+    >>> @requests_mock.Mocker()
     ... def test_func(m):
     ...     m.get('http://test.com', text='data')
     ...     return requests.get('http://test.com').text


### PR DESCRIPTION
I referenced the example from the README but didn't realize there was a discrepancy until https://stackoverflow.com/users/6817835/aws-apprentice pointed it out.

![Screen Shot 2020-01-17 at 10 08 42 PM](https://user-images.githubusercontent.com/12212345/72658398-0de11380-3976-11ea-9293-d955d8ba296d.png)

https://stackoverflow.com/q/59796255/11809808

These changes update the README examples to match the examples on the Read the Docs site: https://requests-mock.readthedocs.io/en/latest/mocker.html.