### PR TITLE
Mark IOReader object closed when using a stream

### DIFF
--- a/releasenotes/notes/fix-iter-content-none-1e29754a75273b8c.yaml
+++ b/releasenotes/notes/fix-iter-content-none-1e29754a75273b8c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - 124 when using `response.iter_content(None)` the iterator would keep
+    returning b'' and never finish. In most code paths the b'' would indicate
+    that the stream is finished, but using None we have to close it ourselves.

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -117,7 +117,15 @@ class _IOReader(six.BytesIO):
             return six.b('')
 
         # not a new style object in python 2
-        return six.BytesIO.read(self, *args, **kwargs)
+        result = six.BytesIO.read(self, *args, **kwargs)
+
+        # when using resp.iter_content(None) it'll go through a different
+        # request path in urllib3. This path checks whether the object is
+        # marked closed instead of the return value. see gh124.
+        if result == six.b(''):
+            self.close()
+
+        return result
 
 
 def create_response(request, **kwargs):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -659,3 +659,27 @@ class SessionAdapterTests(base.TestCase):
         self.assertEqual(netloc, self.adapter.last_request.netloc)
         self.assertEqual(path, self.adapter.last_request.path)
         self.assertEqual(query, self.adapter.last_request.query)
+
+    def test_stream_none(self):
+        text = 'hello world'
+
+        self.adapter.register_uri('GET',
+                                  self.url,
+                                  text=text,
+                                  headers=self.headers)
+
+        resp = self.session.get(self.url, stream=True)
+        resps = [c for c in resp.iter_content(None, decode_unicode=True)]
+        self.assertEqual([text], resps)
+
+    def test_stream_size(self):
+        text = 'hello world'
+
+        self.adapter.register_uri('GET',
+                                  self.url,
+                                  text=text,
+                                  headers=self.headers)
+
+        resp = self.session.get(self.url, stream=True)
+        resps = [c for c in resp.iter_content(3, decode_unicode=True)]
+        self.assertEqual(['hel', 'lo ', 'wor', 'ld'], resps)


### PR DESCRIPTION
When using response.iter_content(None) the path through request is
somewhat different and instead of checking whether the return is empty
it actually checks the closed state of the object.

BytesIO doesn't appear to mark itself as closed automatically when
finished reading so we have to do that ourselves. This doesn't seem to
have any negative effects, but it's deep logic so just have to see.

Fixes: #124