### PR TITLE
Add the default response reason if not set.

### DIFF
--- a/releasenotes/notes/set-default-response-reason-f24556261bc7e9e5.yaml
+++ b/releasenotes/notes/set-default-response-reason-f24556261bc7e9e5.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - When creating a response we now default the reason string to the
+    appropriate string based on the status code. This can still be provided
+    manually.

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -162,9 +162,13 @@ def create_response(request, **kwargs):
     if content is not None:
         body = _IOReader(content)
     if not raw:
-        raw = HTTPResponse(status=kwargs.get('status_code', _DEFAULT_STATUS),
+        status = kwargs.get('status_code', _DEFAULT_STATUS)
+        reason = kwargs.get('reason',
+                            six.moves.http_client.responses.get(status))
+
+        raw = HTTPResponse(status=status,
+                           reason=reason,
                            headers=headers,
-                           reason=kwargs.get('reason'),
                            body=body or _IOReader(six.b('')),
                            decode_content=False,
                            preload_content=False,

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -130,3 +130,25 @@ class ResponseTests(base.TestCase):
         resp = self.create_response(headers=headers,
                                     text="<html><body></body></html")
         self.assertEqual('ISO-8859-1', resp.encoding)
+
+    def test_default_reason(self):
+        resp = self.create_response()
+        self.assertEqual('OK', resp.reason)
+
+    def test_custom_reason(self):
+        reason = 'Live long and prosper'
+        resp = self.create_response(status_code=201, reason=reason)
+
+        self.assertEqual(201, resp.status_code)
+        self.assertEqual(reason, resp.reason)
+
+    def test_some_other_response_reasons(self):
+        reasons = {
+            301: 'Moved Permanently',
+            410: 'Gone',
+            503: 'Service Unavailable',
+        }
+
+        for code, reason in six.iteritems(reasons):
+            self.assertEqual(reason,
+                             self.create_response(status_code=code).reason)


### PR DESCRIPTION
If a user doesn't provide a response reason we autofill this to the
appropriate one based on the provided status code. No decision has been
made here as to what to do if the status code is invalid, it will stll
return None.

Closes: #118