### PR TITLE
Don't check that proxies are set in test.

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -55,7 +55,10 @@ class RequestTests(base.TestCase):
         self.assertIs(False, req.stream)
 
         # actually it's an OrderedDict, but equality works fine
-        self.assertEqual({}, req.proxies)
+        # Skipping this check - it's problematic based on people's environments
+        # and in CI systems where there are proxies set up at the environment
+        # level. gh #127
+        # self.assertEqual({}, req.proxies)
 
     def test_allow_redirects(self):
         req = self.do_request(allow_redirects=False, status_code=300)


### PR DESCRIPTION
There are a bunch of ways that HTTP proxies can be set from outside the
application level. Checking this is set at the library level means that
we don't pass CI or in environments where this is configured.

Closes: #127