### PR TITLE
Move to a PEP440 compliant version check.

### DIFF
--- a/requests_mock/compat.py
+++ b/requests_mock/compat.py
@@ -11,10 +11,12 @@
 # under the License.
 
 import requests
+from packaging.version import parse
 
 
 def _versiontuple(v):
-    return tuple(map(int, (v.split("."))))
+    version = parse(v)
+    return version.release
 
 
 _requests_version = _versiontuple(requests.__version__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+packaging
 requests>=2.3,<3
 six

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from requests_mock.compat import _versiontuple
+from . import base
+
+
+class CompatTests(base.TestCase):
+    def test_compat_parses_release_version(self):
+        self.assertEqual(_versiontuple("2.23.0"), (2, 23, 0))
+
+    def test_compat_supports_local_versions(self):
+        self.assertEqual(_versiontuple("2.23.0+local1"), (2, 23, 0))


### PR DESCRIPTION
Deploying requests-mock along with a locally patched version of requests is difficult due to the check performed in compat.py.

I'm moving this check to be [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant using the ``packaging`` package.

Associated unit test has been added. Happy to expand as needed. 