### PR TITLE
Added reset_mock to _RequestHistoryTracker and Adapter

### DIFF
--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -84,7 +84,7 @@ For mocks, use "reset_mock" method.
     >>> m.call_count
     0
 
-For adapters and matchers, there is a "reset" method.
+For adapters and matchers, there is a "reset" method. Resetting the adapter also resets the associated matchers.
 
 .. doctest::
 
@@ -101,6 +101,8 @@ For adapters and matchers, there is a "reset" method.
     >>> matcher.called  # Reset adapter also resets associated matchers
     False
 
+However, resetting the matcher does not reset the adapter.
+
 .. doctest::
 
     >>> session.get('mock://test.com')
@@ -109,5 +111,5 @@ For adapters and matchers, there is a "reset" method.
     >>> matcher.reset()
     >>> matcher.called
     False
-    >>> adapter.called()  # Reset matcher does not reset adapter
+    >>> adapter.called  # Reset matcher does not reset adapter
     True

--- a/doc/source/history.rst
+++ b/doc/source/history.rst
@@ -66,3 +66,48 @@ The following parameters of the :py:func:`requests.request` call are also expose
 :cert: The client certificate or cert/key tuple for this request.
 
 Note: That the default value of these attributes are the values that are passed to the adapter and not what is passed to the request method. This means that the default for allow_redirects is None (even though that is interpretted as True) if unset, whereas the defautl for verify is True, and the default for proxies the empty dict.
+
+Reset History
+===============
+
+For mocks, adapters, and matchers, the history can be reset. This can be useful when testing complex code with multiple requests. 
+
+For mocks, use "reset_mock" method.
+
+.. doctest::
+
+    >>> m.called
+    True
+    >>> m.reset_mock()
+    >>> m.called
+    False
+    >>> m.call_count
+    0
+
+For adapters and matchers, there is a "reset" method.
+
+.. doctest::
+
+    >>> adapter = requests_mock.adapter.Adapter()
+    >>> matcher = adapter.register_uri('GET', 'mock://test.com', text='resp')
+    >>> session = requests.Session()
+    >>> session.mount('mock://', adapter)
+    >>> session.get('mock://test.com')
+    >>> adapter.called
+    True
+    >>> adapter.reset()
+    >>> adapter.called
+    False
+    >>> matcher.called  # Reset adapter also resets associated matchers
+    False
+
+.. doctest::
+
+    >>> session.get('mock://test.com')
+    >>> matcher.called
+    True
+    >>> matcher.reset()
+    >>> matcher.called
+    False
+    >>> adapter.called()  # Reset matcher does not reset adapter
+    True

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -62,7 +62,7 @@ class _RequestHistoryTracker(object):
     def call_count(self):
         return len(self.request_history)
 
-    def reset_mock(self):
+    def reset(self):
         self.request_history = []
 
 
@@ -308,10 +308,10 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
         """
         self._matchers.append(matcher)
 
-    def reset_mock(self):
-        super(Adapter, self).reset_mock()
+    def reset(self):
+        super(Adapter, self).reset()
         for matcher in self._matchers:
-            matcher.reset_mock()
+            matcher.reset()
 
 
 __all__ = ['Adapter']

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -309,7 +309,7 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
         self._matchers.append(matcher)
 
     def reset_mock(self):
-        super().reset_mock()
+        super(Adapter, self).reset_mock()
         for matcher in self._matchers:
             matcher.reset_mock()
 

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -62,6 +62,9 @@ class _RequestHistoryTracker(object):
     def call_count(self):
         return len(self.request_history)
 
+    def reset_mock(self):
+        self.request_history = []
+
 
 class _RunRealHTTP(Exception):
     """A fake exception to jump out of mocking and allow a real request.
@@ -304,6 +307,11 @@ class Adapter(BaseAdapter, _RequestHistoryTracker):
         :param callable matcher: The matcher to execute.
         """
         self._matchers.append(matcher)
+
+    def reset_mock(self):
+        super().reset_mock()
+        for matcher in self._matchers:
+            matcher.reset_mock()
 
 
 __all__ = ['Adapter']

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -42,7 +42,6 @@ class MockerCore(object):
         'called',
         'called_once',
         'call_count',
-        'reset_mock',
     }
 
     case_sensitive = False
@@ -137,6 +136,9 @@ class MockerCore(object):
         if self._last_send:
             requests.Session.send = self._last_send
             self._last_send = None
+
+    def reset_mock(self):
+        self._adapter.reset()
 
     def __getattr__(self, name):
         if name in self._PROXY_FUNCS:

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -42,6 +42,7 @@ class MockerCore(object):
         'called',
         'called_once',
         'call_count',
+        'reset_mock',
     }
 
     case_sensitive = False

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -20,6 +20,7 @@ from six.moves.urllib import parse as urlparse
 
 import requests_mock
 from . import base
+from unittest.mock import patch
 
 
 class MyExc(Exception):
@@ -382,6 +383,23 @@ class SessionAdapterTests(base.TestCase):
         self.assertEqual(len(resps), self.adapter.call_count)
         self.assertTrue(self.adapter.called)
         self.assertFalse(m.called_once)
+
+    def test_called_and_reset(self):
+        m = self.adapter.register_uri('GET', self.url, text='resp')
+        call_count = 3
+
+        [self.session.get(self.url) for _ in range(0, call_count)]
+
+        # Verify count is expected value for adapter and matcher
+        self.assertEqual(self.adapter.call_count, call_count)
+        self.assertEqual(m.call_count, call_count)
+
+        with patch.object(m, 'reset_mock') as m_matcher_reset:
+            self.adapter.reset_mock()
+            # Assert adapter reset calls reset on matcher
+            m_matcher_reset.assert_called_once()
+
+        self.assertEqual(self.adapter.call_count, 0)
 
     def test_adapter_picks_correct_adapter(self):
         good = '%s://test3.url/' % self.PREFIX

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -392,7 +392,8 @@ class SessionAdapterTests(base.TestCase):
         m = self.adapter.register_uri('GET', self.url, text='resp')
         call_count = 3
 
-        [self.session.get(self.url) for _ in range(0, call_count)]
+        for _ in range(0, call_count):
+            self.session.get(self.url)
 
         # Verify count is expected value for adapter and matcher
         self.assertEqual(self.adapter.call_count, call_count)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -389,14 +389,14 @@ class SessionAdapterTests(base.TestCase):
         matcher_count = 3
         for i in range(matcher_count):
             url = self.url + str(i)
-            m = self.adapter.register_uri('GET', url, text='resp')
+            self.adapter.register_uri('GET', url, text='resp')
             for _ in range(call_count):
                 self.session.get(url)
 
         # Verify call counts on adapter and matchers
         self.assertEqual(self.adapter.call_count, matcher_count * call_count)
-        for m in self.adapter._matchers:
-            self.assertEqual(m.call_count, call_count)
+        for matcher in self.adapter._matchers:
+            self.assertEqual(matcher.call_count, call_count)
 
         self.adapter.reset()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -390,7 +390,7 @@ class SessionAdapterTests(base.TestCase):
         for i in range(matcher_count):
             url = self.url + str(i)
             m = self.adapter.register_uri('GET', url, text='resp')
-            for j in range(call_count):
+            for _ in range(call_count):
                 self.session.get(url)
 
         # Verify call counts on adapter and matchers

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -20,7 +20,11 @@ from six.moves.urllib import parse as urlparse
 
 import requests_mock
 from . import base
-from unittest.mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 class MyExc(Exception):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -402,8 +402,8 @@ class SessionAdapterTests(base.TestCase):
 
         # Verify call counts are 0 after reset
         self.assertEqual(self.adapter.call_count, 0)
-        for m in self.adapter._matchers:
-            self.assertEqual(m.call_count, 0)
+        for matcher in self.adapter._matchers:
+            self.assertEqual(matcher.call_count, 0)
 
     def test_adapter_picks_correct_adapter(self):
         good = '%s://test3.url/' % self.PREFIX

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -14,6 +14,7 @@ import re
 
 from requests_mock import adapter
 from . import base
+from unittest.mock import MagicMock
 
 ANY = adapter.ANY
 
@@ -294,3 +295,22 @@ class TestMatcher(base.TestCase):
                            matcher_method='POST',
                            request_data='goodbye world',
                            additional_matcher=test_match_body)
+
+    def test_reset_mock_resets_count(self):
+        url = 'mock://test/site/'
+        matcher = adapter._Matcher('GET',
+                                   url,
+                                   [MagicMock()],
+                                   complete_qs=False,
+                                   additional_matcher=None,
+                                   request_headers={},
+                                   real_http=False,
+                                   case_sensitive=False)
+        request = adapter._RequestObjectProxy._create('GET', url)
+
+        call_count = 3
+        [matcher(request) for _ in range(call_count)]
+
+        self.assertEqual(matcher.call_count, call_count)
+        matcher.reset_mock()
+        self.assertEqual(matcher.call_count, 0)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -309,7 +309,8 @@ class TestMatcher(base.TestCase):
         request = adapter._RequestObjectProxy._create('GET', url)
 
         call_count = 3
-        [matcher(request) for _ in range(call_count)]
+        for _ in range(call_count):
+            matcher(request)
 
         self.assertEqual(matcher.call_count, call_count)
         matcher.reset_mock()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -296,7 +296,7 @@ class TestMatcher(base.TestCase):
                            request_data='goodbye world',
                            additional_matcher=test_match_body)
 
-    def test_reset_mock_resets_count(self):
+    def test_reset_reverts_count(self):
         url = 'mock://test/site/'
         matcher = adapter._Matcher('GET',
                                    url,
@@ -313,5 +313,5 @@ class TestMatcher(base.TestCase):
             matcher(request)
 
         self.assertEqual(matcher.call_count, call_count)
-        matcher.reset_mock()
+        matcher.reset()
         self.assertEqual(matcher.call_count, 0)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -14,7 +14,7 @@ import re
 
 from requests_mock import adapter
 from . import base
-from unittest.mock import MagicMock
+from requests_mock.response import _MatcherResponse
 
 ANY = adapter.ANY
 
@@ -300,7 +300,7 @@ class TestMatcher(base.TestCase):
         url = 'mock://test/site/'
         matcher = adapter._Matcher('GET',
                                    url,
-                                   [MagicMock()],
+                                   [_MatcherResponse()],
                                    complete_qs=False,
                                    additional_matcher=None,
                                    request_headers={},

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -20,7 +20,11 @@ from requests_mock import adapter
 from requests_mock import exceptions
 from requests_mock import response
 from . import base
-from unittest.mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 original_send = requests.Session.send
 

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -244,16 +244,16 @@ class MockerTests(base.TestCase):
         self.assertEqual(copy_of_mocker.real_http, mocker.real_http)
 
     @requests_mock.mock()
-    def test_reset_mock_reverts_call_count(self, m):
+    def test_reset_mock_reverts_call_count(self, request_mock):
         url = 'http://test.url/path'
-        m.get(url, text='resp')
-        resp = requests.get(url)
+        request_mock.get(url, text='resp')
+        requests.get(url)
 
-        self.assertEqual(m.call_count, 1)
+        self.assertEqual(request_mock.call_count, 1)
 
         # reset count and verify it is 0
-        m.reset_mock()
-        self.assertEqual(m.call_count, 0)
+        request_mock.reset_mock()
+        self.assertEqual(request_mock.call_count, 0)
 
 
 class MockerHttpMethodsTests(base.TestCase):

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -20,6 +20,7 @@ from requests_mock import adapter
 from requests_mock import exceptions
 from requests_mock import response
 from . import base
+from unittest.mock import patch
 
 original_send = requests.Session.send
 
@@ -242,6 +243,16 @@ class MockerTests(base.TestCase):
         self.assertIsNot(copy_of_mocker, mocker)
         self.assertEqual(copy_of_mocker._kw, mocker._kw)
         self.assertEqual(copy_of_mocker.real_http, mocker.real_http)
+
+    def test_reset_mock_calls_adapter_reset_mock(self):
+        mocker = requests_mock.mock()
+        mocker.get('mock://test/url/', text='test_reponse')
+
+        # Verify mocker.reset_mock calls reset_mock on adapter
+        with patch.object(mocker._adapter, 'reset_mock') as m_adapter_reset:
+            mocker.reset_mock()
+            # Assert adapter reset calls reset on matcher
+            m_adapter_reset.assert_called_once()
 
 
 class MockerHttpMethodsTests(base.TestCase):

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -249,14 +249,14 @@ class MockerTests(base.TestCase):
         self.assertEqual(copy_of_mocker.real_http, mocker.real_http)
 
     def test_reset_mock_calls_adapter_reset_mock(self):
-        mocker = requests_mock.mock()
-        mocker.get('mock://test/url/', text='test_reponse')
+        with requests_mock.Mocker() as mocker:
+            self.assertMockStarted()
 
-        # Verify mocker.reset_mock calls reset_mock on adapter
-        with patch.object(mocker._adapter, 'reset_mock') as m_adapter_reset:
-            mocker.reset_mock()
-            # Assert adapter reset calls reset on matcher
-            m_adapter_reset.assert_called_once()
+            # Verify mocker.reset_mock calls reset_mock on adapter
+            with patch.object(mocker._adapter, 'reset_mock') as m_adapter_reset:
+                mocker.reset_mock()
+                # Assert adapter reset calls reset on matcher
+                m_adapter_reset.assert_called_once()
 
 
 class MockerHttpMethodsTests(base.TestCase):


### PR DESCRIPTION
I added reset_mock to Mocker, Adapter and Matcher.

Mocker().reset_mock() just passes it on to the adapter.  I.e. it got added to Mocker._PROXY_FUNCS

Adapter(...).reset_mock() resets its own request_history and loops through matchers and calls reset_mock() on them as well.  

I briefly considered implementing Matcher(...).reset_mock(url=<new_url>, text=<new_response>).  That would be more parallel to unittest.mock.reset_mock().  This is still doable, but I figured this was a good chunk for now.  This could be an add-on later if desired or I can add it now.  

Ex.
```
import requests
from requests_mock import Mocker

with Mocker() as m:
    m.get('mock://my.url', text='some response')
    requests.get('mock://my.url')
    assert(m.call_count == 1)
    m.reset_mock()
    assert(m.call_count == 0)

with Mocker() as m:
    matcher = m.get('mock://my.url', text='some response')
    requests.get('mock://my.url')
    assert(matcher.call_count == 1)
    matcher.reset_mock()  # This does not change adapter count!!
    assert(matcher.call_count == 0)
```
