### PR TITLE
Add release notes for reset function

### DIFF
--- a/releasenotes/notes/add-reset-function-bcef01162cab0912.yaml
+++ b/releasenotes/notes/add-reset-function-bcef01162cab0912.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a reset/reset_mock function to the mocker and components so that users
+    can clear the calls and history from the Mocker without clearing all the
+    matching that has been used.

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -42,6 +42,7 @@ class MockerCore(object):
         'called',
         'called_once',
         'call_count',
+        'reset',
     }
 
     case_sensitive = False
@@ -138,8 +139,9 @@ class MockerCore(object):
             requests.Session.send = self._last_send
             self._last_send = None
 
+    # for familiarity with MagicMock
     def reset_mock(self):
-        self._adapter.reset()
+        self.reset()
 
     def __getattr__(self, name):
         if name in self._PROXY_FUNCS:


### PR DESCRIPTION
Adds the release note, but also adds the reset() to the Mocker so that
it's consistent across all the objects.