### PR TITLE
Remove requests 2.3 compatibility code

### DIFF
--- a/requests_mock/compat.py
+++ b/requests_mock/compat.py
@@ -13,13 +13,6 @@
 import requests
 
 
-def _versiontuple(v):
-    return tuple(map(int, (v.split("."))))
-
-
-_requests_version = _versiontuple(requests.__version__)
-
-
 class _FakeHTTPMessage(object):
 
     def __init__(self, headers):
@@ -37,24 +30,3 @@ class _FakeHTTPMessage(object):
             return [self.headers[name]]
         except KeyError:
             return failobj
-
-
-class _FakeHTTPResponse(object):
-
-    def __init__(self, headers):
-        self.msg = _FakeHTTPMessage(headers)
-
-    def isclosed(self):
-        # Don't let urllib try to close me
-        return False
-
-
-if _requests_version < (2, 3):
-    # NOTE(jamielennox): There is a problem with requests < 2.3.0 such that it
-    # needs a httplib message for use with cookie extraction. It has been fixed
-    # but it is needed until we can rely on a recent enough requests version.
-
-    _fake_http_response = _FakeHTTPResponse({})
-
-else:
-    _fake_http_response = None

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -180,7 +180,7 @@ def create_response(request, **kwargs):
                            body=body or _IOReader(six.b('')),
                            decode_content=False,
                            preload_content=False,
-                           original_response=compat._fake_http_response)
+                           original_response=None)
 
     response = _http_adapter.build_response(request, raw)
     response.connection = connection


### PR DESCRIPTION
The code that parses the requests version is broken when used in
conjunction with PEP440 full versions. It doesn't handle +local and a
number of other cases.

However this code is only being used to check if we're using requests <
2.3 and our requirements have been updated so that we depend on a
requests newer than this.

Therefore instead of fixing the version code lets just remove the
compatability layer.