### PR TITLE
Create Set-Cookie header from the cookie jar (fix #17)

### DIFF
--- a/requests_mock/compat.py
+++ b/requests_mock/compat.py
@@ -30,3 +30,13 @@ class _FakeHTTPMessage(object):
             return [self.headers[name]]
         except KeyError:
             return failobj
+
+
+class _FakeHTTPResponse(object):
+    
+    def __init__(self, headers):
+        self._headers = headers
+        self.msg = _FakeHTTPMessage(headers)
+    
+    def isclosed(self):
+        return True

--- a/tests/test_session_cookies.py
+++ b/tests/test_session_cookies.py
@@ -1,0 +1,16 @@
+import requests
+import requests_mock
+
+from . import base
+
+
+class SessionCookiesTest(base.TestCase):
+    def test_cookie(self):
+        with requests_mock.Mocker() as m:
+            m.get("mock://test.site", text="hello", cookies={"name": "value"})
+
+            with requests.Session() as s:
+                r = s.get("mock://test.site")
+
+                self.assertEquals(r.cookies.get("name"), "value")
+                self.assertEquals(s.cookies.get("name"), "value")


### PR DESCRIPTION
Hi!

This PR hopefully fixes issue #17 by manually creating the `Set-Cookie` HTTP header in the `create_response` function. 

I also had to create `compat._FakeHTTPResponse` in order to make Requests happy: as you mentioned in the issue, [`extract_cookies_to_jar`](https://github.com/psf/requests/blob/2a7832b5b06d377c7c79d1170b07e41fbd1a5d7c/requests/cookies.py#L118) works by accessing `HTTPResponse._original_response`, which wasn't populated.

I also added a test which makes sure that cookies are propagated down to the Session object.

Let me know what you think :)