### PR TITLE
fix: `session` and `real_http` cannot be used at the same time

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -30,6 +30,16 @@ PUT = 'PUT'
 _original_send = requests.Session.send
 
 
+def is_bound_method(method):
+    """
+    bound_method 's self is a obj
+    unbound_method 's self is None
+    """
+    if isinstance(method, types.MethodType) and six.get_method_self(method):
+        return True
+    return False
+
+
 def _set_method(target, name, method):
     """ Set a mocked method onto the target.
 
@@ -38,7 +48,7 @@ def _set_method(target, name, method):
 
     If method is a bound_method, can direct setattr
     """
-    if not isinstance(target, type) and not isinstance(method, types.MethodType):
+    if not isinstance(target, type) and not is_bound_method(method):
         method = six.create_bound_method(method, target)
 
     setattr(target, name, method)

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -30,7 +30,7 @@ PUT = 'PUT'
 _original_send = requests.Session.send
 
 
-def is_bound_method(method):
+def _is_bound_method(method):
     """
     bound_method 's self is a obj
     unbound_method 's self is None
@@ -48,7 +48,7 @@ def _set_method(target, name, method):
 
     If method is a bound_method, can direct setattr
     """
-    if not isinstance(target, type) and not is_bound_method(method):
+    if not isinstance(target, type) and not _is_bound_method(method):
         method = six.create_bound_method(method, target)
 
     setattr(target, name, method)

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import functools
+import types
 
 import requests
 import six
@@ -34,8 +35,10 @@ def _set_method(target, name, method):
 
     Target may be either an instance of a Session object of the
     requests.Session class. First we Bind the method if it's an instance.
+
+    If method is a bound_method, can direct setattr
     """
-    if not isinstance(target, type):
+    if not isinstance(target, type) and not isinstance(method, types.MethodType):
         method = six.create_bound_method(method, target)
 
     setattr(target, name, method)

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -181,9 +181,9 @@ class MockerTests(base.TestCase):
                                                           status_code=200,
                                                           content=test_bytes)
 
-        s = requests.Session()
-        with requests_mock.Mocker(session=s, real_http=True) as m:
-            resp = s.get(url)
+        session = requests.Session()
+        with requests_mock.Mocker(session=session, real_http=True):
+            resp = session.get(url)
 
         self.assertEqual(test_text, resp.text)
         self.assertEqual(test_bytes, resp.content)

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -170,6 +170,24 @@ class MockerTests(base.TestCase):
         self.assertEqual(test_text, resp.text)
         self.assertEqual(test_bytes, resp.content)
 
+    @mock.patch('requests.adapters.HTTPAdapter.send')
+    def test_real_http_and_session(self, real_send):
+        url = 'http://www.google.com/'
+        test_text = 'real http data'
+        test_bytes = test_text.encode('utf-8')
+
+        req = requests.Request(method='GET', url=url)
+        real_send.return_value = response.create_response(req.prepare(),
+                                                          status_code=200,
+                                                          content=test_bytes)
+
+        s = requests.Session()
+        with requests_mock.Mocker(session=s, real_http=True) as m:
+            resp = s.get(url)
+
+        self.assertEqual(test_text, resp.text)
+        self.assertEqual(test_bytes, resp.content)
+
     @requests_mock.mock()
     def test_with_test_decorator(self, m):
         self._do_test(m)


### PR DESCRIPTION
 #145 

If method is a bound_method, can direct setattr

I add a testcase, and fixed it