### PR TITLE
Correctly handle an explicit zero byte read

### DIFF
--- a/releasenotes/notes/fix-zero-bytes-read-109628b72221cfe7.yaml
+++ b/releasenotes/notes/fix-zero-bytes-read-109628b72221cfe7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - Issue 144 - When performing a read we handled an empty byte return as an
+    indication to close the file pointer. This is not true when you actually
+    ask for a zero byte read so we should allow it.

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -116,6 +116,11 @@ class _IOReader(six.BytesIO):
         if self.closed:
             return six.b('')
 
+        # if the file is open, but you asked for zero bytes read you should get
+        # back zero without closing the stream.
+        if len(args) > 0 and args[0] == 0:
+            return six.b('')
+
         # not a new style object in python 2
         result = six.BytesIO.read(self, *args, **kwargs)
 

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -566,3 +566,16 @@ class MockerHttpMethodsTests(base.TestCase):
         self.assertEqual(text, new_resp.text)
         self.assertIsInstance(orig_resp.request.matcher, adapter._Matcher)
         self.assertIsNone(new_resp.request.matcher)
+
+    @requests_mock.mock()
+    def test_stream_zero_bytes(self, m):
+        content = b'blah'
+
+        m.get("http://test", content=content)
+        res = requests.get("http://test", stream=True)
+        zero_val = res.raw.read(0)
+        self.assertEqual(b'', zero_val)
+        self.assertFalse(res.raw.closed)
+
+        full_val = res.raw.read()
+        self.assertEqual(content, full_val)


### PR DESCRIPTION
Normally doing a read and getting nothing back implies the stream is
closed an you can't read any more from it. However there are times where
you might do this on purpose and not expect the stream to close so
handle that case explicitly.

Closes: #144