### PR TITLE
Mocker.copy: Use correct type when copying mocker

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -251,7 +251,7 @@ class Mocker(MockerCore):
     def copy(self):
         """Returns an exact copy of current mock
         """
-        m = Mocker(
+        m = type(self)(
             kw=self._kw,
             real_http=self.real_http,
             case_sensitive=self.case_sensitive


### PR DESCRIPTION
As per the sole commit:

> Currently, the `copy` method hard-codes the `Mocker` class as the return type. In order to allow this to work with sub-classes of `Mocker`, this commit replaces it with the type of the instance.