### PR TITLE
Url Quote the path provided to the mocker

### DIFF
--- a/releasenotes/notes/url-quote-path-a593190dee974a7a.yaml
+++ b/releasenotes/notes/url-quote-path-a593190dee974a7a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - Fix [#148](https://github.com/jamielennox/requests-mock/issues/158). When
+    you have a non url-safe character in your URL it is quoted by requests
+    however requests-mock just treated it as a normal string.

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -102,7 +102,7 @@ class _Matcher(_RequestHistoryTracker):
             url_parts = urlparse.urlparse(url)
             self._scheme = url_parts.scheme.lower()
             self._netloc = url_parts.netloc.lower()
-            self._path = url_parts.path or '/'
+            self._path = urlparse.quote(url_parts.path or '/')
             self._query = url_parts.query
 
             if not case_sensitive:

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -15,9 +15,9 @@ def test_simple(requests_mock):
 
 
 def test_redirect_and_nesting():
-    url_inner = "inner_mock://example.test/"
-    url_middle = "middle_mock://example.test/"
-    url_outer = "outer_mock://example.test/"
+    url_inner = "inner-mock://example.test/"
+    url_middle = "middle-mock://example.test/"
+    url_outer = "outer-mock://example.test/"
     url_base = "https://www.example.com/"
 
     text_middle = 'middle' + url_middle

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -141,6 +141,8 @@ class TestMatcher(base.TestCase):
                              'http://www.test.com/abc')
         self.assertMatchBoth('http://www.test.com:5000/abc',
                              'http://www.test.com:5000/abc')
+        self.assertMatchBoth('http://www.test.com/a string%url',
+                             'http://www.test.com/a string%url')
 
         self.assertNoMatchBoth('https://www.test.com',
                                'http://www.test.com')


### PR DESCRIPTION
Requests-mock safely quotes things like spaces and non-url safe
characters. We should do the same thing so that the matchers work.

Closes: #158