### PR TITLE
Fix DeprecationWarnings in setup.cfg keys

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
 name = requests-mock
 author = Jamie Lennox
-author-email = jamielennox@gmail.com
+author_email = jamielennox@gmail.com
 summary = Mock out responses from the requests package
-description-file = README.rst
+description_file = README.rst
 license = Apache-2
-license-file = LICENSE
-home-page = https://requests-mock.readthedocs.io/
+license_file = LICENSE
+home_page = https://requests-mock.readthedocs.io/
 classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
The dash-separated option keys in setup.cfg are deprecated since
setuptools 54.1.0, use underscore-separated names instead.