### PR TITLE
Restore py.typed file to enable types

### DIFF
--- a/releasenotes/notes/Add-py.typed-file-5a5cae1041dd0859.yaml
+++ b/releasenotes/notes/Add-py.typed-file-5a5cae1041dd0859.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - A py.typed file is required to enable type annotations for the package. Add to pack for re-release.


### PR DESCRIPTION
Without this type annotations aren't picked up. This should not have
been deleted.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information

Closes: #165