### PR TITLE
Revert "Url Quote the path provided to the mocker"

### DIFF
--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -102,7 +102,7 @@ class _Matcher(_RequestHistoryTracker):
             url_parts = urlparse.urlparse(url)
             self._scheme = url_parts.scheme.lower()
             self._netloc = url_parts.netloc.lower()
-            self._path = urlparse.quote(url_parts.path or '/')
+            self._path = url_parts.path or '/'
             self._query = url_parts.query
 
             if not case_sensitive:

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -15,9 +15,9 @@ def test_simple(requests_mock):
 
 
 def test_redirect_and_nesting():
-    url_inner = "inner-mock://example.test/"
-    url_middle = "middle-mock://example.test/"
-    url_outer = "outer-mock://example.test/"
+    url_inner = "inner_mock://example.test/"
+    url_middle = "middle_mock://example.test/"
+    url_outer = "outer_mock://example.test/"
     url_base = "https://www.example.com/"
 
     text_middle = 'middle' + url_middle

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -141,8 +141,6 @@ class TestMatcher(base.TestCase):
                              'http://www.test.com/abc')
         self.assertMatchBoth('http://www.test.com:5000/abc',
                              'http://www.test.com:5000/abc')
-        self.assertMatchBoth('http://www.test.com/a string%url',
-                             'http://www.test.com/a string%url')
 
         self.assertNoMatchBoth('https://www.test.com',
                                'http://www.test.com')


### PR DESCRIPTION
This change broke existing behavior for users who were already quoting mocked endpoints.

This change also differs slightly from requests's behavior, so it is no longer possible to register some URIs. For example, if "@" is in the URL path, requests does not quote this character, but the requests-mock matcher quotes it to "%40", so the matcher never triggers.

This reverts commit f072845c0cb13c6c0fb18824160639a8bb3c7fe8.