### PR TITLE
Use requests to quote URLs

### DIFF
--- a/releasenotes/notes/Fix-urlquote-of-quoted-path-84cc1ff122dba279.yaml
+++ b/releasenotes/notes/Fix-urlquote-of-quoted-path-84cc1ff122dba279.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - As part of 1.9.0 we started quoting unsafe URL characters. This was done incorrectly that meant we requoted existing quoted strings. Fixes #170.

--- a/requests_mock/adapter.py
+++ b/requests_mock/adapter.py
@@ -13,6 +13,7 @@
 import weakref
 
 from requests.adapters import BaseAdapter
+from requests.utils import requote_uri
 import six
 from six.moves.urllib import parse as urlparse
 
@@ -102,7 +103,7 @@ class _Matcher(_RequestHistoryTracker):
             url_parts = urlparse.urlparse(url)
             self._scheme = url_parts.scheme.lower()
             self._netloc = url_parts.netloc.lower()
-            self._path = urlparse.quote(url_parts.path or '/')
+            self._path = requote_uri(url_parts.path or '/')
             self._query = url_parts.query
 
             if not case_sensitive:

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -141,9 +141,6 @@ class TestMatcher(base.TestCase):
                              'http://www.test.com/abc')
         self.assertMatchBoth('http://www.test.com:5000/abc',
                              'http://www.test.com:5000/abc')
-        self.assertMatchBoth('http://www.test.com/a string%url',
-                             'http://www.test.com/a string%url')
-
         self.assertNoMatchBoth('https://www.test.com',
                                'http://www.test.com')
         self.assertNoMatchBoth('http://www.test.com/abc',
@@ -160,6 +157,14 @@ class TestMatcher(base.TestCase):
                                'http://www.test.com/abc')
         self.assertNoMatchBoth('http://test.com/abc/',
                                'http://www.test.com:5000/abc')
+
+    def test_quotation(self):
+        self.assertMatchBoth('http://www.test.com/a string%url',
+                             'http://www.test.com/a string%url')
+        self.assertMatchBoth('http://www.test.com/ABC 123',
+                             'http://www.test.com/ABC%20123')
+        self.assertMatchBoth('http://www.test.com/user@example.com',
+                             'http://www.test.com/user@example.com')
 
     def test_subset_match(self):
         self.assertMatch('/path', 'http://www.test.com/path')


### PR DESCRIPTION
The previous fix to jamielennox#158 didn't match requests' own behavior and quoted a lot of additional characters, causing test breakage.

Use `requests.utils.requote_uri` to quote the URL instead, which should ensure the behavior matches requests more closely.

---

I did some brief testing: tests that broke with 1.9.0 (mostly due to `:` in the path component) now pass and spaces are now correctly escaped (the original issue mentioned in #158), while leaving most reserved characters untouched.