### PR TITLE
Improve request matching type stubs

### DIFF
--- a/requests_mock/adapter.pyi
+++ b/requests_mock/adapter.pyi
@@ -2,9 +2,11 @@
 
 from requests.adapters import BaseAdapter
 from requests_mock import _RequestObjectProxy
-from typing import Any, List, Optional
+from typing import Any, Callable, Dict, List, NewType, Optional, Pattern, Union
 
-ANY: object = ...
+AnyMatcher = NewType("AnyMatcher", object)
+
+ANY: AnyMatcher = ...
 
 class _RequestHistoryTracker:
     request_history: List[_RequestObjectProxy] = ...
@@ -26,5 +28,17 @@ class _Matcher(_RequestHistoryTracker):
 
 class Adapter(BaseAdapter, _RequestHistoryTracker):
     def __init__(self, case_sensitive: bool = ...) -> None: ...
-    def register_uri(self, method: Any, url: Any, response_list: Optional[Any] = ..., **kwargs: Any) -> Any: ...
+    def register_uri(
+        self,
+        method: Union[str, AnyMatcher],
+        url: Union[str, Pattern[str], AnyMatcher],
+        response_list: Optional[List[Dict[str, Any]]] = ...,
+        request_headers: Dict[str, str] = ...,
+        complete_qs: bool = ...,
+        status_code: int = ...,
+        text: str = ...,
+        headers: Optional[Dict[str, str]] = ...,
+        additional_matcher: Optional[Callable[[_RequestObjectProxy], bool]] = ...,
+        **kwargs: Any
+    ) -> Any: ...
     def add_matcher(self, matcher: Any) -> None: ...

--- a/requests_mock/mocker.pyi
+++ b/requests_mock/mocker.pyi
@@ -30,7 +30,8 @@ class MockerCore:
     def call_count(self) -> int: ...
     def register_uri(
       self,
-      method: str,
+      method: Union[str, Any],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -38,7 +39,8 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def request(
       self,
-      method: str,
+      method: Union[str, Any],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -46,7 +48,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def get(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -54,7 +56,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def head(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -62,7 +64,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def options(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -70,7 +72,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def post(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -78,7 +80,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def put(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -86,7 +88,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def patch(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -94,7 +96,7 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def delete(
       self,
-      path: Union[str, Pattern[str]],
+      url: Union[str, Pattern[str], Any],
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,

--- a/requests_mock/mocker.pyi
+++ b/requests_mock/mocker.pyi
@@ -1,5 +1,6 @@
 # Stubs for requests_mock.mocker
 
+from requests_mock.adapter import AnyMatcher
 from requests import Response
 from requests_mock.request import _RequestObjectProxy
 from typing import Any, Callable, Dict, List, Optional, Pattern, Type, TypeVar, Union
@@ -30,8 +31,11 @@ class MockerCore:
     def call_count(self) -> int: ...
     def register_uri(
       self,
-      method: Union[str, Any],
-      url: Union[str, Pattern[str], Any],
+      method: Union[str, AnyMatcher],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -39,8 +43,11 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def request(
       self,
-      method: Union[str, Any],
-      url: Union[str, Pattern[str], Any],
+      method: Union[str, AnyMatcher],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -48,7 +55,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def get(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -56,7 +66,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def head(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -64,7 +77,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def options(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -72,7 +88,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def post(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -80,7 +99,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def put(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -88,7 +110,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def patch(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,
@@ -96,7 +121,10 @@ class MockerCore:
       **kwargs: Any) -> Response: ...
     def delete(
       self,
-      url: Union[str, Pattern[str], Any],
+      url: Union[str, Pattern[str], AnyMatcher],
+      response_list: Optional[List[Dict[str, Any]]] = ...,
+      request_headers: Dict[str, str] = ...,
+      complete_qs: bool = ...,
       status_code: int = ...,
       text: str = ...,
       headers: Optional[Dict[str, str]] = ...,


### PR DESCRIPTION
Addresses #171

Improvements:
- Adds the missing `url` parameter to the `register_uri` and `request` methods.
- Renames the `path` parameters of `delete`, `get`, `head`, `options`, `patch`, `post`, and `put` methods to `url` to match the name of the corresponding parameter in `requests_mock.adapter.Adapter.register_uri`.
- Changes the types of various `method` and `url` parameters to support the `requests_mock.adapter.ANY` "wildcard" value.
- Introduces the `AnyMatcher` type for the `requests_mock.adapter.ANY` matcher (thanks, @pcorpet!).
- Adds the `request_headers` and `complete_qs` request matching parameters to `MockerCore`'s registration methods (e.g. `register_uri`, `request`, get`, etc.).
- Adds the `response_list` parameter to `MockerCore`'s registration methods so that it can be specified as a positional argument as in the [documentation](https://requests-mock.readthedocs.io/en/latest/response.html#response-lists)'s examples.
- Ensures that `Adapter`'s `register_uri` method supports the same request matching parameters as `MockerCore`'s `register_uri`.