### PR TITLE
Fix failing pytest

### DIFF
--- a/tests/test_custom_matchers.py
+++ b/tests/test_custom_matchers.py
@@ -31,13 +31,6 @@ def match_all(request):
     return requests_mock.create_response(request, content=six.b('data'))
 
 
-def test_a(request):
-    if 'a' in request.url:
-        return match_all(request)
-
-    return None
-
-
 class CustomMatchersTests(base.TestCase):
 
     def assertMatchAll(self, resp):
@@ -65,7 +58,14 @@ class CustomMatchersTests(base.TestCase):
 
     @requests_mock.Mocker()
     def test_some_pass(self, mocker):
-        mocker.add_matcher(test_a)
+
+        def matcher_a(request):
+            if 'a' in request.url:
+                return match_all(request)
+
+            return None
+
+        mocker.add_matcher(matcher_a)
 
         resp = requests.get('http://any/thing')
         self.assertMatchAll(resp)


### PR DESCRIPTION
When you start a method with test_ pytest loads it and tries to parse
the parameters as fixtures. In this case it's not a real test, just a
matcher function used later on in the test file.

We can inline it into the function as it's only used in one place.

Fixes: #175