### PR TITLE
Add real_http config option for pytest

### DIFF
--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -23,6 +23,8 @@ except Exception:
 if not _pytest29:
     _case_type = None
     _case_default = 'false'
+    _real_http_type = None
+    _real_http_default = 'false'
 
     # Copied from pytest 2.9.0 where bool was introduced. It's what happens
     # internally if we specify a bool type argument.
@@ -49,6 +51,8 @@ if not _pytest29:
 else:
     _case_type = 'bool'
     _case_default = False
+    _real_http_type = 'bool'
+    _real_http_default = False
 
     def _bool_value(value):
         return value
@@ -65,6 +69,10 @@ def pytest_addoption(parser):
                   'Use case sensitive matching in requests_mock',
                   type=_case_type,
                   default=_case_default)
+    parser.addini('requests_mock_real_http',
+                  'Forward requests to the real server if not mocked',
+                  type=_real_http_type,
+                  default=_real_http_default)
 
 
 @_fixture_type(scope='function')  # executed on every test
@@ -76,7 +84,11 @@ def requests_mock(request):
     https://requests-mock.readthedocs.io/en/latest/
     """
     case_sensitive = request.config.getini('requests_mock_case_sensitive')
-    kw = {'case_sensitive': _bool_value(case_sensitive)}
+    real_http = request.config.getini('requests_mock_real_http')
+    kw = {
+        'case_sensitive': _bool_value(case_sensitive),
+        'real_http': _bool_value(real_http)
+    }
 
     with rm_module.Mocker(**kw) as m:
         yield m

--- a/tests/pytest/pytest.ini
+++ b/tests/pytest/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 requests_mock_case_sensitive=false
+requests_mock_real_http=true

--- a/tests/pytest/test_with_pytest.py
+++ b/tests/pytest/test_with_pytest.py
@@ -14,6 +14,19 @@ def test_simple(requests_mock):
     assert 'data' == requests.get('https://httpbin.org/get').text
 
 
+def test_real_http(requests_mock):
+    requests_mock.get('https://httpbin.org/get', text='data')
+    assert 'data' == requests.get('https://httpbin.org/get').text
+
+    test_response = requests.post(
+        'https://httpbin.org/post',
+        json={'test': 'val'}
+    )
+
+    assert test_response.status_code == 200
+    assert test_response.json()['json'] == {'test': 'val'}
+
+
 def test_redirect_and_nesting():
     url_inner = "inner-mock://example.test/"
     url_middle = "middle-mock://example.test/"


### PR DESCRIPTION
Hi!

I found the pytest plugin that comes with `request-mock` to be really useful in mocking dependencies. Thanks for this!

I was using it to write tests for a microservice that needed a mix of mocked and actual HTTP requests but realized that `real_http` wasn't configurable using pytest.ini
Currently, you can work around this by wrapping the pytest function using `@requests_mock.Mocker(real_http=True, kw='m')` but I felt it's nicer to have a global option for certain use cases. It also greatly reduces repetitive setup code.

I've included the option under the pytest plugin & added a simple test to ensure it works.

Hope you can consider this and let me know if it needs more work!