### PR TITLE
Minor changes to code snippet example

### DIFF
--- a/doc/source/matching.rst
+++ b/doc/source/matching.rst
@@ -242,7 +242,7 @@ This is handled by a callback function that takes the request as a parameter:
     ...     return 'hello' in (request.text or '')
     ...
     >>> adapter.register_uri('POST', 'mock://test.com/additional', additional_matcher=match_request_text, text='resp')
-    >>> session.post('mock://test.com/headers', data='hello world').text
+    >>> session.post('mock://test.com/additional', data='hello world').text
     'resp'
     >>> resp = session.post('mock://test.com/additional', data='goodbye world')
     Traceback (most recent call last):


### PR DESCRIPTION
I was reviewing the document, and I noticed the small discrepancy between the examples used in this section.

I think the goal here is to highlight a use case for `additional_matcher` or *Custom Matching*. Therefore, the URL should be constant.