### PR TITLE
pytest plugin should lazy-load requests_mock

### DIFF
--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -75,6 +75,8 @@ def requests_mock(request):
     responses for unit testing. See:
     https://requests-mock.readthedocs.io/en/latest/
     """
+    # pytest plugins get loaded immediately. If we import requests_mock it
+    # imports requests and then SSL which prevents gevent patching. Late load.
     import requests_mock as rm_module
 
     case_sensitive = request.config.getini('requests_mock_case_sensitive')

--- a/requests_mock/contrib/_pytest_plugin.py
+++ b/requests_mock/contrib/_pytest_plugin.py
@@ -1,5 +1,4 @@
 import pytest
-import requests_mock as rm_module
 
 
 # RHEL 7 ships pytest 2.7 which doesn't have the 'bool' type to addini. This
@@ -76,6 +75,8 @@ def requests_mock(request):
     responses for unit testing. See:
     https://requests-mock.readthedocs.io/en/latest/
     """
+    import requests_mock as rm_module
+
     case_sensitive = request.config.getini('requests_mock_case_sensitive')
     kw = {'case_sensitive': _bool_value(case_sensitive)}
 


### PR DESCRIPTION
Importing `requests_mock` early (during pytest initialization) drags in `requests` which drags in `ssl`.

Not only it slows down pytest startup, in the gevent "ecosystem" it interferes with the ability to do gevent monkey-patching early on.