### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ description_file = README.rst
 license = Apache-2
 license_file = LICENSE
 home_page = https://requests-mock.readthedocs.io/
+project_urls =
+    Source = https://github.com/jamielennox/requests-mock
 classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)