### PR TITLE
Shorten line length of comments

### DIFF
--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -46,7 +46,8 @@ def threading_rlock(timeout):
         kwargs['timeout'] = timeout
 
     if not _send_lock.acquire(**kwargs):
-        raise Exception("Could not acquire threading lock - possible deadlock scenario")
+        m = "Could not acquire threading lock - possible deadlock scenario"
+        raise Exception(m)
 
     try:
         yield

--- a/requests_mock/mocker.py
+++ b/requests_mock/mocker.py
@@ -168,15 +168,16 @@ class MockerCore(object):
                 # are doing here.
                 _set_method(session, "get_adapter", _fake_get_adapter)
 
-                # NOTE(jamielennox): self._last_send vs _original_send. Whilst it
-                # seems like here we would use _last_send there is the possibility
-                # that the user has messed up and is somehow nesting their mockers.
-                # If we call last_send at this point then we end up calling this
-                # function again and the outer level adapter ends up winning.
-                # All we really care about here is that our adapter is in place
-                # before calling send so we always jump directly to the real
-                # function so that our most recently patched send call ends up
-                # putting in the most recent adapter. It feels funny, but it works.
+                # NOTE(jamielennox): self._last_send vs _original_send. Whilst
+                # it seems like here we would use _last_send there is the
+                # possibility that the user has messed up and is somehow
+                # nesting their mockers.  If we call last_send at this point
+                # then we end up calling this function again and the outer
+                # level adapter ends up winning.  All we really care about here
+                # is that our adapter is in place before calling send so we
+                # always jump directly to the real function so that our most
+                # recently patched send call ends up putting in the most recent
+                # adapter. It feels funny, but it works.
 
                 try:
                     return _original_send(session, request, **kwargs)


### PR DESCRIPTION
This was recently indented another level which caused the test to fail
and block PRs