### PR TITLE
Revert threading.lock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ pytest
 sphinx
 testrepository>=0.0.18
 testtools
-requests_futures


### PR DESCRIPTION
Reverts the PR #183 to get PR tests working again. Bug to track changes in #201.