### PR TITLE
Update homepage/doc URLs of requests library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations
 under the License.
 
-.. _requests: http://python-requests.org
+.. _requests: https://requests.readthedocs.io
 .. _docs: https://requests-mock.readthedocs.io/
 .. _GitHub: https://github.com/jamielennox/requests-mock
 .. _StackOverflow: https://stackoverflow.com/questions/tagged/requests-mock

--- a/doc/source/adapter.rst
+++ b/doc/source/adapter.rst
@@ -31,6 +31,6 @@ If you are not familiar with adapters, prefer the mocker approach (see :ref:`Moc
 
 At this point any requests made by the session to a URI starting with `mock://` will be sent to our adapter.
 
-.. _requests: http://python-requests.org
+.. _requests: https://requests.readthedocs.io
 .. _transport adapter: https://requests.readthedocs.io/en/master/user/advanced/#transport-adapters
 .. _mount: https://requests.readthedocs.io/en/master/api/#requests.Session.mount

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -255,7 +255,7 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-requests_uri = 'http://docs.python-requests.org/en/latest/'
+requests_uri = 'https://requests.readthedocs.io/en/latest/'
 urllib3_uri = 'https://urllib3.readthedocs.io/en/latest/'
 python_uri = 'https://docs.python.org/3/'
 intersphinx_mapping = {'requests': (requests_uri, None),

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -11,8 +11,8 @@ This is particularly useful in unit tests where you want to return known respons
 As the `requests`_ library has very limited options for how to load and use adapters *requests-mock* also provides a number of ways to make sure the mock adapter is used.
 These are only loading mechanisms, they do not contain any logic and can be used as a reference to load the adapter in whatever ways works best for your project.
 
-.. _requests: http://python-requests.org
-.. _pluggable transport adapters: http://docs.python-requests.org/en/latest/user/advanced/#transport-adapters
+.. _requests: https://requests.readthedocs.io
+.. _pluggable transport adapters: https://requests.readthedocs.io/en/latest/user/advanced/#transport-adapters
 
 Installation
 ============


### PR DESCRIPTION
The docs currently point in a couple of places to outdated requests homepage http://python-requests.org/

at the moment this URL even gives me a "domain suspension" form:
![Screenshot from 2022-06-24 15-39-10](https://user-images.githubusercontent.com/44946/175547699-6232fdfd-dd32-492b-bc6f-87a4f8d4aab2.png)

This PR updates these old URLs to current homepage https://requests.readthedocs.io/
