### PR TITLE
allow json_encoder kwarg when passing exc

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -227,7 +227,7 @@ class _MatcherResponse(object):
         # If the user is asking for an exception to be thrown then prevent them
         # specifying any sort of body or status response as it won't be used.
         # This may be protecting the user too much but can be removed later.
-        if self._exc and kwargs:
+        if self._exc and [x for x in kwargs if x != "json_encoder"]:
             raise TypeError('Cannot provide other arguments with exc.')
 
         _check_body_arguments(**kwargs)


### PR DESCRIPTION
With the `json_encoder` change in https://github.com/jamielennox/requests-mock/pull/198/commits/f70ba9277f580ecb6dec1daee3487b5b45772f3e, our tests now need to set our custom encoder in a requests_mock fixture. This causes the following to fail as the `json_encoder` kwarg is passed into the `_MatcherResponse`
```
self = <requests_mock.response._MatcherResponse object at 0x7f3c068f2b60>, kwargs = {'json_encoder': <class 'RestResponse.objects.RestEncoder'>}

    def __init__(self, **kwargs):
        self._exc = kwargs.pop('exc', None)
    
        # If the user is asking for an exception to be thrown then prevent them
        # specifying any sort of body or status response as it won't be used.
        # This may be protecting the user too much but can be removed later.
        if self._exc and kwargs:
>           raise TypeError('Cannot provide other arguments with exc.')
E           TypeError: Cannot provide other arguments with exc.
```