### PR TITLE
Adds test for query string values

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -137,3 +137,7 @@ class RequestTests(base.TestCase):
     def test_empty_query_string(self):
         req = self.do_request(url='https://host.example.com/path?key')
         self.assertEqual([''], req.qs['key'])
+    
+    def test_query_string(self):
+        req = self.do_request(url='https://host.example.com/path?key=value')
+        self.assertEqual('value', req.qs['key'])


### PR DESCRIPTION
Added a test for the case observed in #221, where the `qs` attribute can sometimes be empty.