### PR TITLE
Typing analysis and public type aliases

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install flake8
+        pip install -r typing-requirements.txt
 
     - name: Lint with flake8
       run: flake8 requests_mock tests
+
+    - name: Lint type hinting with MyPy
+      run: mypy requests_mock

--- a/releasenotes/notes/public-type-aliases-f389506932adfa2c.yaml
+++ b/releasenotes/notes/public-type-aliases-f389506932adfa2c.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Exposes some public type aliases (for type hinting only, they can't be instanciated) 
+    for the types intended to be used by `requests_mock` users. 
+    The following types are now exposed:
+    - `requests_mock.Context` used in callbacks
+    - `requests_mock.Request` used in callbacks, which is a `requests.PreparedRequest` proxy.
+    - `requests_mock.Callback[T]` which is the callbacks type.
+
+fixes:
+  - |
+    Some typing inconsistencies have been fixed. 
+    Especially for `request` object in signatures which is in fact a `requests_mock.Request` object.

--- a/requests_mock/__init__.pyi
+++ b/requests_mock/__init__.pyi
@@ -1,7 +1,33 @@
 # Stubs for requests_mock
 
-from requests_mock.adapter import ANY as ANY, Adapter as Adapter
-from requests_mock.exceptions import MockException as MockException, NoMockAddress as NoMockAddress
-from requests_mock.mocker import DELETE as DELETE, GET as GET, HEAD as HEAD, Mocker as Mocker, MockerCore as MockerCore, OPTIONS as OPTIONS, PATCH as PATCH, POST as POST, PUT as PUT, mock as mock
-from requests_mock.request import _RequestObjectProxy as _RequestObjectProxy
-from requests_mock.response import CookieJar as CookieJar, create_response as create_response
+from requests_mock.adapter import (
+    ANY as ANY, 
+    Adapter as Adapter, 
+    Callback as Callback, 
+    AdditionalMatcher as AdditionalMatcher,
+)
+from requests_mock.exceptions import (
+    MockException as MockException, 
+    NoMockAddress as NoMockAddress,
+)
+from requests_mock.mocker import (
+    DELETE as DELETE, 
+    GET as GET, 
+    HEAD as HEAD,
+    Mocker as Mocker,
+    MockerCore as MockerCore,
+    OPTIONS as OPTIONS,
+    PATCH as PATCH,
+    POST as POST,
+    PUT as PUT,
+    mock as mock,
+)
+from requests_mock.request import (
+    Request as Request,
+    _RequestObjectProxy as _RequestObjectProxy,  # For backward compatibility
+)
+from requests_mock.response import (
+    CookieJar as CookieJar,
+    create_response as create_response,
+    Context as Context,
+)

--- a/requests_mock/contrib/_pytest_plugin.pyi
+++ b/requests_mock/contrib/_pytest_plugin.pyi
@@ -1,0 +1,6 @@
+
+from typing import Literal, Optional, Union
+
+
+_case_type = Optional[str]
+_case_default = Union[Literal['false'], Literal[False]]

--- a/requests_mock/mocker.pyi
+++ b/requests_mock/mocker.pyi
@@ -5,12 +5,11 @@ from http.cookiejar import CookieJar
 from io import IOBase
 from typing import Any, Callable, Dict, List, Optional, Pattern, Type, TypeVar, Union
 
-from requests import Request, Response, Session
-from requests.packages.urllib3.response import HTTPResponse
+from requests import Response, Session
+from urllib3.response import HTTPResponse
 
-from requests_mock.adapter import AnyMatcher, _Matcher
-from requests_mock.request import _RequestObjectProxy
-from requests_mock.response import _Context
+from requests_mock.adapter import AnyMatcher, _Matcher, Callback, AdditionalMatcher
+from requests_mock.request import Request
 
 DELETE: str
 GET: str
@@ -27,9 +26,9 @@ class MockerCore:
     def stop(self) -> None: ...
     def add_matcher(self, matcher: Callable[[Request], Optional[Response]]) -> None: ...
     @property
-    def request_history(self) -> List[_RequestObjectProxy]: ...
+    def request_history(self) -> List[Request]: ...
     @property
-    def last_request(self) -> Optional[_RequestObjectProxy]: ...
+    def last_request(self) -> Optional[Request]: ...
     @property
     def called(self) -> bool: ...
     @property
@@ -51,13 +50,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -74,13 +73,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -96,13 +95,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -118,13 +117,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -140,13 +139,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -162,13 +161,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -184,13 +183,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -206,13 +205,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...
@@ -228,13 +227,13 @@ class MockerCore:
       reason: str = ...,
       headers: Dict[str, str] = ...,
       cookies: Union[CookieJar, Dict[str, str]] = ...,
-      json: Union[Any, Callable[[_RequestObjectProxy, _Context], Any]] = ...,
-      text: Union[str, Callable[[_RequestObjectProxy, _Context], str]] = ...,
-      content: Union[bytes, Callable[[_RequestObjectProxy, _Context], bytes]] = ...,
-      body: Union[IOBase, Callable[[_RequestObjectProxy, _Context], IOBase]] = ...,
+      json: Union[Any, Callback[Any]] = ...,
+      text: Union[str, Callback[str]] = ...,
+      content: Union[bytes, Callback[bytes]] = ...,
+      body: Union[IOBase, Callback[IOBase]] = ...,
       raw: HTTPResponse = ...,
       exc: Union[Exception, Type[Exception]] = ...,
-      additional_matcher: Callable[[_RequestObjectProxy], bool] = ...,
+      additional_matcher: AdditionalMatcher = ...,
       json_encoder: Optional[Type[JSONEncoder]] = ...,
       **kwargs: Any,
     ) -> _Matcher: ...

--- a/requests_mock/request.pyi
+++ b/requests_mock/request.pyi
@@ -36,3 +36,6 @@ class _RequestObjectProxy:
     def json(self, **kwargs: Any) -> Any: ...
     @property
     def matcher(self) -> Any: ...
+    
+
+Request = _RequestObjectProxy

--- a/requests_mock/response.pyi
+++ b/requests_mock/response.pyi
@@ -1,6 +1,6 @@
 # Stubs for requests_mock.response
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import six
 
@@ -34,3 +34,5 @@ class _Context:
 class _MatcherResponse:
     def __init__(self, **kwargs: Any) -> None: ...
     def get_response(self, request: Request) -> Response: ...
+
+Context = _Context

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,7 @@ fixture =
 [entry_points]
 pytest11 =
     requests_mock = requests_mock.contrib._pytest_plugin
+
+[mypy]
+[mypy-fixtures]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     pypy
     pypy3
     pep8
+    typing
 
 [testenv]
 setenv =
@@ -92,3 +93,8 @@ deps =
     six
     -egit+https://github.com/kennethreitz/requests.git#egg=requests
     -r{toxinidir}/test-requirements.txt
+
+[testenv:typing]
+commands = mypy requests_mock
+deps =
+    -r{toxinidir}/typing-requirements.txt

--- a/typing-requirements.txt
+++ b/typing-requirements.txt
@@ -1,0 +1,3 @@
+mypy
+types-requests
+types-six


### PR DESCRIPTION
Hello 👋🏼 

This pull-requests adds:
- a `tox` `typing` task performing type hinting analysis using MyPy
- rename the `flake8.yml` workflow into `lint.yml` (consistent with its `name`)
- add MyPy to the `Lint` workflow
- exposes some type aliases (so there are not instanciable as expected in https://github.com/jamielennox/requests-mock/issues/92#issuecomment-514890445)  for type intended for `requests_mock` users:
  - `requests_mock.Context` to use in response callbacks (alias for `requests_mock.response._Context`)
  - `requests_mock.Request` to use in response callbacks (alias for `requests_mock.request._RequestObjectProxy`)
  - `requests_mock.Callback[T]` to type response callbacks (alias for `Callable[[requests_mock.Request, requests_mock.Context], T]`)
- fixes all mistyping to `requests.Request` which are in fact request proxies (typed `requests_mock.Request`)
- fixes all MyPy errors including those from `requests_mock.contrib`

This pull-requests doesn't introduce any functional change (no `.py` file touched, only `.pyi` stubs)