### PR TITLE
Remove testrepository dependency

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -38,7 +38,7 @@ jobs:
           pip install -e .
 
       - name: Test Testtools
-        run: python setup.py testr
+        run: python -m testtools.run discover
 
       - name: Test PyTest
         run: pytest tests/pytest
@@ -66,7 +66,7 @@ jobs:
           pip install -e .
 
       - name: Test Testtools
-        run: python setup.py testr
+        run: python -m testtools.run discover
 
       - name: Test PyTest
         run: pytest tests/pytest

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ output/*/index.html
 doc/build
 doc/source/_build
 
-.testrepository
 .pytest_cache
 tests/pytest/.cache/
 

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-test_command=python -m subunit.run discover $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,5 @@ mock
 purl
 pytest
 sphinx
-testrepository>=0.0.18
 testtools
 requests_futures

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/requests-mock
 commands =
     pytest tests/pytest
-    python setup.py testr
+    python -m testtools.run {posargs:discover}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
@@ -38,7 +38,7 @@ deps =
 [testenv:oldest-requirements]
 install_command = pip install -U {opts} -c {toxinidir}/.tox.oldest.txt {packages}
 commands =
-    python setup.py testr --testr-args='{posargs}'
+    python -m testtools.run {posargs:discover}
 deps =
     -r{toxinidir}/test-requirements.txt
     -c{toxinidir}/.tox.oldest.txt

--- a/tox.ini
+++ b/tox.ini
@@ -58,30 +58,6 @@ deps =
     pbr
     {[testenv]deps}
 
-[testenv:keystoneclient-tip]
-deps =
-    six
-    -r{toxinidir}/test-requirements.txt
-    -egit+https://git.openstack.org/openstack/python-keystoneclient#egg=python-keystoneclient
-    -egit+https://github.com/kennethreitz/requests.git#egg=requests
-changedir = {envdir}/src/python-keystoneclient
-commands =
-    {envbindir}/pip install -r requirements.txt -r test-requirements.txt
-    {envbindir}/pip install pbr -t {envsitepackagesdir} # work around pbr being build installed in {toxinidir}
-    python setup.py testr --testr-args='{posargs}'
-
-[testenv:novaclient-tip]
-deps =
-    six
-    -r{toxinidir}/test-requirements.txt
-    -egit+https://git.openstack.org/openstack/python-novaclient#egg=python-novaclient
-    -egit+https://github.com/kennethreitz/requests.git#egg=requests
-changedir = {envdir}/src/python-novaclient
-commands =
-    {envbindir}/pip install -r requirements.txt -r test-requirements.txt
-    {envbindir}/pip install pbr -t {envsitepackagesdir} # work around pbr being build installed in {toxinidir}
-    python setup.py testr --testr-args='{posargs}'
-
 [testenv:docs]
 commands = python setup.py build_sphinx
 deps =
@@ -91,7 +67,7 @@ deps =
 [testenv:requests-tip]
 deps =
     six
-    -egit+https://github.com/kennethreitz/requests.git#egg=requests
+    -e "git+https://github.com/kennethreitz/requests.git\#egg=requests"
     -r{toxinidir}/test-requirements.txt
 
 [testenv:typing]


### PR DESCRIPTION
Testrepository was a speed up required when you had lots of tests running simultaneously. It was copied from openstack, but it appears to be abandoned these days. If not it's still a dependency we shouldn't need so remove it.