### PR TITLE
Tell urllib3 to ignore content length mismatch

### DIFF
--- a/releasenotes/notes/urllib3-2-content-length-mismatch-d98e782a25c41266.yaml
+++ b/releasenotes/notes/urllib3-2-content-length-mismatch-d98e782a25c41266.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix incompatibility with urllib3 >2.0.0. In 2.0.0 they default to enforcing
+    content length checking on returned bodies in responses from the previous
+    default of false. However the flag is still available so for compatibility
+    we can just default the other way.

--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -195,6 +195,7 @@ def create_response(request, **kwargs):
                            headers=headers,
                            body=body or _IOReader(six.b('')),
                            decode_content=False,
+                           enforce_content_length=False,
                            preload_content=False,
                            original_response=None)
 

--- a/tests/test_mocker.py
+++ b/tests/test_mocker.py
@@ -625,3 +625,19 @@ class MockerHttpMethodsTests(base.TestCase):
         m.get("http://test", json={"a": "b"}, json_encoder=MyJsonEncoder)
         res = requests.get("http://test")
         self.assertEqual(test_val, res.text)
+
+    @requests_mock.mock()
+    def test_mismatch_content_length_streaming(self, m):
+        url = "https://test/package.tar.gz"
+
+        def f(request, context):
+            context.headers["Content-Length"] = "300810"
+            return None
+
+        m.head(
+            url=url,
+            status_code=200,
+            text=f,
+        )
+
+        requests.head(url)


### PR DESCRIPTION
In urllib3 v2 they default enforce_content_length to true. This fails now when you mock a request that doesn't have any data that can be partially read.

Fixes: #228