### PR TITLE
Update copyright year

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'requests-mock'
-copyright = u'2014, Jamie Lennox'
+copyright = u'2023, Jamie Lennox'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Thank you for this project, its a really helpful package.
Leaving the docs' copyright as 2014 makes it appear (from only reading just the docs) that the project might be stale.
Updating it to avoid putting people off