### PR TITLE
six is not needed for literals

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -120,12 +120,12 @@ class _IOReader(six.BytesIO):
 
     def read(self, *args, **kwargs):
         if self.closed:
-            return six.b('')
+            return b''
 
         # if the file is open, but you asked for zero bytes read you should get
         # back zero without closing the stream.
         if len(args) > 0 and args[0] == 0:
-            return six.b('')
+            return b''
 
         # not a new style object in python 2
         result = six.BytesIO.read(self, *args, **kwargs)
@@ -133,7 +133,7 @@ class _IOReader(six.BytesIO):
         # when using resp.iter_content(None) it'll go through a different
         # request path in urllib3. This path checks whether the object is
         # marked closed instead of the return value. see gh124.
-        if result == six.b(''):
+        if result == b'':
             self.close()
 
         return result
@@ -193,7 +193,7 @@ def create_response(request, **kwargs):
         raw = HTTPResponse(status=status,
                            reason=reason,
                            headers=headers,
-                           body=body or _IOReader(six.b('')),
+                           body=body or _IOReader(b''),
                            decode_content=False,
                            enforce_content_length=False,
                            preload_content=False,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -59,7 +59,7 @@ class SessionAdapterTests(base.TestCase):
         self.assertEqual(qs, self.adapter.last_request.qs)
 
     def test_content(self):
-        data = six.b('testdata')
+        data = b'testdata'
 
         self.adapter.register_uri('GET',
                                   self.url,
@@ -72,7 +72,7 @@ class SessionAdapterTests(base.TestCase):
 
     def test_content_callback(self):
         status_code = 401
-        data = six.b('testdata')
+        data = b'testdata'
 
         def _content_cb(request, context):
             context.status_code = status_code
@@ -127,8 +127,8 @@ class SessionAdapterTests(base.TestCase):
                                   json=json_data,
                                   headers=self.headers)
         resp = self.session.get(self.url)
-        self.assertEqual(six.b('{"hello": "world"}'), resp.content)
-        self.assertEqual(six.u('{"hello": "world"}'), resp.text)
+        self.assertEqual(b'{"hello": "world"}', resp.content)
+        self.assertEqual(u'{"hello": "world"}', resp.text)
         self.assertEqual(json_data, resp.json())
         self.assertEqual('utf-8', resp.encoding)
         self.assertHeaders(resp)
@@ -157,7 +157,7 @@ class SessionAdapterTests(base.TestCase):
     def test_no_body(self):
         self.adapter.register_uri('GET', self.url)
         resp = self.session.get(self.url)
-        self.assertEqual(six.b(''), resp.content)
+        self.assertEqual(b'', resp.content)
         self.assertEqual(200, resp.status_code)
 
     def test_multiple_body_elements(self):
@@ -165,8 +165,8 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           self.url,
                           'GET',
-                          content=six.b('b'),
-                          text=six.u('u'))
+                          content=b'b',
+                          text=u'u')
 
     def test_multiple_responses(self):
         inp = [{'status_code': 400, 'text': 'abcd'},
@@ -264,14 +264,14 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          content=six.u('unicode'))
+                          content=u'unicode')
 
     def test_dont_pass_empty_string_as_content(self):
         self.assertRaises(TypeError,
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          content=six.u(''))
+                          content=u'')
 
     def test_dont_pass_bytes_as_text(self):
         if six.PY2:
@@ -281,7 +281,7 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          text=six.b('bytes'))
+                          text=b'bytes')
 
     def test_dont_pass_empty_string_as_text(self):
         if six.PY2:
@@ -291,7 +291,7 @@ class SessionAdapterTests(base.TestCase):
                           self.adapter.register_uri,
                           'GET',
                           self.url,
-                          text=six.b(''))
+                          text=b'')
 
     def test_dont_pass_non_str_as_content(self):
         self.assertRaises(TypeError,

--- a/tests/test_custom_matchers.py
+++ b/tests/test_custom_matchers.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import requests
-import six
 
 import requests_mock
 from . import base
@@ -28,14 +27,14 @@ class FailMatcher(object):
 
 
 def match_all(request):
-    return requests_mock.create_response(request, content=six.b('data'))
+    return requests_mock.create_response(request, content=b'data')
 
 
 class CustomMatchersTests(base.TestCase):
 
     def assertMatchAll(self, resp):
         self.assertEqual(200, resp.status_code)
-        self.assertEqual(resp.text, six.u('data'))
+        self.assertEqual(resp.text, u'data')
 
     @requests_mock.Mocker()
     def test_custom_matcher(self, mocker):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -49,12 +49,12 @@ class ResponseTests(base.TestCase):
 
         # this only works on python 2 because bytes is a string
         if six.PY3:
-            self.assertRaises(TypeError, self.create_response, text=six.b(''))
+            self.assertRaises(TypeError, self.create_response, text=b'')
 
     def test_text_type(self):
-        self.assertRaises(TypeError, self.create_response, content=six.u('t'))
+        self.assertRaises(TypeError, self.create_response, content=u't')
         self.assertRaises(TypeError, self.create_response, content={'a': 1})
-        self.assertRaises(TypeError, self.create_response, content=six.u(''))
+        self.assertRaises(TypeError, self.create_response, content=u'')
 
     def test_json_body(self):
         data = {'a': 1}


### PR DESCRIPTION
this remains compatible with Python 2.6+

https://wiki.debian.org/Python3-six-removal