### PR TITLE
fix(mocker.pyi): fix Mocker class type hints

### DIFF
--- a/requests_mock/mocker.pyi
+++ b/requests_mock/mocker.pyi
@@ -247,6 +247,7 @@ class Mocker(MockerCore):
 
     def __init__(
       self,
+      *,
       kw: str = ...,
       case_sensitive: bool = ...,
       adapter: Any = ...,


### PR DESCRIPTION
Hello there!
Found minor issue with typing of Mocker class.
So, here is my silly fix for it.
Thank you for review in advance!