### PR TITLE
Remove unused `six` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ packages = requests_mock
 include_package_data = true
 install_requires =
     requests>=2.22,<3
-    six
 
 [build_sphinx]
 all_files = 1


### PR DESCRIPTION
The dependency was left in metadata, but removed with https://github.com/jamielennox/requests-mock/commit/c74eb15026a67eaa734a208be1e0e660bf2a7083
Fixes #211