### PR TITLE
Fix for request forcing query string paramters to lower case

### DIFF
--- a/requests_mock/request.py
+++ b/requests_mock/request.py
@@ -109,7 +109,9 @@ class _RequestObjectProxy(object):
     @property
     def qs(self):
         if self._qs is None:
-            self._qs = urllib.parse.parse_qs(self.query,
+            query_string = urllib.parse.urlparse(self._request.url).query
+
+            self._qs = urllib.parse.parse_qs(query_string,
                                              keep_blank_values=True)
 
         return self._qs

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -137,3 +137,8 @@ class RequestTests(base.TestCase):
     def test_empty_query_string(self):
         req = self.do_request(url='https://host.example.com/path?key')
         self.assertEqual([''], req.qs['key'])
+
+    def test_capitalized_query_paramters(self):
+        req = self.do_request(url='https://host.example.com/path?key=VALUE')
+        self.assertEqual(['VALUE'], req.qs['key'])
+


### PR DESCRIPTION
This addresses issue #264.  Simple change to work around lower casing of the query string here: https://github.com/jamielennox/requests-mock/blob/9742d02a8cad17276dbeba7b300b6d27ae1b6fb1/requests_mock/request.py#L60-L61

I added a test to prevent regression.